### PR TITLE
Fix for parameters on renaming guest and admin accounts

### DIFF
--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
@@ -183,7 +183,7 @@ Class ScaffoldingBlock{
                     $This.ResourceParameters['ValueData'] = $Name
                 }
 
-                'AccountPolicy'{
+                {$_ -in ('SecurityOption','AccountPolicy')}{
                     [string]$Name = "$('$')$($This.RecommendationVersioned.ToString().Replace('.',''))$($This.ResourceParameters['Name'].replace("'",'').replace('_',''))"
                     $ValueKey = $This.ResourceParameters['Name'].replace("'",'')
                     [string]$DataType = "[$($This.ResourceParameters[$ValueKey].GetType().Name)]"


### PR DESCRIPTION
- Added missing SecurityOption to parameter switch statement.
- Resolution for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/50

Parameters now show up as expected
![image](https://user-images.githubusercontent.com/28571284/89676550-78758480-d8b1-11ea-8b4d-0b7144685b37.png)
