### PR TITLE
added static assertions

### DIFF
--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.schema.psm1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.schema.psm1.plaster
@@ -9,5 +9,18 @@ Configuration CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
+    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains '2315AccountsRenameadministratoraccount'){
+        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "2315AccountsRenameadministratoraccount"'
+    }
+    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains '2316AccountsRenameguestaccount'){
+        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "2316AccountsRenameguestaccount"'
+    }
+    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains '2375LegalNoticeText'){
+        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "2375LegalNoticeText"'
+    }
+    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains '2376LegalNoticeCaption'){
+        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "2376LegalNoticeCaption"'
+    }
+
 <%=$PLASTER_PARAM_DSCScaffolding%>
 }


### PR DESCRIPTION
- Solution for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/35

- Plaster template was updated to check for user provided values for specific recommendations if they where not excluded. Marking the parameters mandatory was not an option since it would require these be specified even if excluded.