### PR TITLE
Small bug fixes

### DIFF
--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
@@ -51,7 +51,7 @@ Class Recommendation{
             {$_ -like "*or fewer*"}{$This.DSCParameter = $True}
             {$_ -like "*or greater*"}{$This.DSCParameter = $True}
             {$_ -like "*or less*"}{$This.DSCParameter = $True}
-            {$_ -like "*between*"}{$This.DSCParameter = $True}
+            #{$_ -like "*between*"}{$This.DSCParameter = $True} this was causing false positives.
             {$_ -eq "(L1) Configure 'Interactive logon: Message text for users attempting to log on'"}{$This.DSCParameter = $True}
             {$_ -eq "(L1) Configure 'Interactive logon: Message title for users attempting to log on'"}{$This.DSCParameter = $True}
             {$_ -eq "(L1) Configure 'Accounts: Rename administrator account'"}{$This.DSCParameter = $True}

--- a/src/CISDSCResourceGeneration/functions/private/Resolve-RegistryValueSpecialCases.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Resolve-RegistryValueSpecialCases.ps1
@@ -16,5 +16,15 @@ Function Resolve-RegistryValueSpecialCases
             #Change the type to REG_SZ
             $regHash.ValueType = '1'
         }
+
+        "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\PauseFeatureUpdatesStartTime"{
+            #There is an encoding error on registry.pol that makes this a mystery character instead of the intended '0'.
+            $regHash.ValueData = "'0'"
+        }
+
+        "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\PauseQualityUpdatesStartTime"{
+            #There is an encoding error on registry.pol that makes this a mystery character instead of the intended '0'.
+            $regHash.ValueData = "'0'"
+        }
     }
 }


### PR DESCRIPTION
- Commented out "between" being a keyword for a parameter as this was causing false positives.

- Added 2 registry special cases that were repeat offenders of an encoding issue.