### PR TITLE
Added registry special case for LegalNoticeText

### DIFF
--- a/src/CISDSCResourceGeneration/functions/private/ConvertFrom-RegistryValueRawGPO.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/ConvertFrom-RegistryValueRawGPO.ps1
@@ -48,6 +48,8 @@ Function ConvertFrom-RegistryValueRawGPO {
         }
     }
 
+    $regHash = Resolve-RegistryValueSpecialCases -regHash $regHash
+
     switch($regHash['ValueType']){
         '1' {
             $regHash['ValueType'] = "'String'"

--- a/src/CISDSCResourceGeneration/functions/private/Resolve-RegistryValueSpecialCases.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Resolve-RegistryValueSpecialCases.ps1
@@ -30,6 +30,12 @@ Function Resolve-RegistryValueSpecialCases
             $regHash.ValueData = 0
             $regHash.ValueType = 'Dword'
         }
+
+        'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeText'{
+            #This value is set as a multi string value but needs to be a standard string.
+            $regHash.ValueData = '"ADD TEXT HERE"'
+            $regHash.ValueType = '1'
+        }
     }
 
     return $regHash


### PR DESCRIPTION
This was incorrectly removed in a previous PR and was causing this to create a string array parameter vs a string.