### PR TITLE
altered DSCtitle logic

### DIFF
--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
@@ -57,8 +57,8 @@ Class Recommendation{
         $This.RecommendationNum = $ExcelRow.'recommendation #'
         #Quotes are normalized for consistentcy in checks.
         $This.Title = $ExcelRow.Title.Replace('"',"'")
-        #Most special characters are filtered out of the title for the DSC resource. This prevents various encoding issues.
-        $This.DSCTitle = $This.Title -replace "[^a-zA-Z0-9() ]",""
+        #Most special characters are filtered out of the title for the DSC resource. This prevents various encoding issues. Recommendation number is added to the start to prevent duplicate titles between recommendations which does occur.
+        $This.DSCTitle = "$($This.RecommendationNum) - $($This.Title)" -replace "[^a-zA-Z0-9-() .]",""
         $This.Description = $ExcelRow.Description
         $This.RemediationProcedure = $ExcelRow.'remediation procedure'
         $This.AuditProcedure = $ExcelRow.'audit procedure'

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -41,11 +41,11 @@ Describe 'Class: Recommendation' {
         }
 
         It 'Sanitizes the title for the resulting DSC' -TestCases @(
-            @{ Title = "(L1) Ensure 'Enforce password history' is set to '24 or more password(s)'"; Expectation = "(L1) Ensure Enforce password history is set to 24 or more password(s)"},
-            @{ Title = "(L1) Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'"; Expectation = "(L1) Ensure Interactive logon Do not require CTRLALTDEL is set to Disabled"},
+            @{ Title = "(L1) Ensure 'Enforce password history' is set to '24 or more password(s)'"; Expectation = "1.1.1 - (L1) Ensure Enforce password history is set to 24 or more password(s)"},
+            @{ Title = "(L1) Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'"; Expectation = "1.1.1 - (L1) Ensure Interactive logon Do not require CTRLALTDEL is set to Disabled"},
             @{ Title = @"
 (L1) Ensure 'Remove access to “Pause updates” feature' is set to 'Enabled''
-"@; Expectation = "(L1) Ensure Remove access to Pause updates feature is set to Enabled" }
+"@; Expectation = "1.1.1 - (L1) Ensure Remove access to Pause updates feature is set to Enabled" }
         ){
             $ExcelExample = (Import-Excel -Path "$($PSScriptRoot)\example_files\desktop_examples.xlsx" -WorksheetName 'Level 1 (L1) - Corporate_Enter' |
                 Where-Object -FilterScript {$_.Title -like "(L1)*"})[0]


### PR DESCRIPTION
The previous refactor changed the logic in which resource titles are de-duplicated which is a requirement for DSC. This introduced a bug for duplicate titles in separate recommendations which is rare but happens. See below example where the same title is used to describe a client setting and a server setting for WinRM. This change will prefix the title with the recommendation number to ensure this does not happen.


![image](https://user-images.githubusercontent.com/28571284/92624548-416a0880-f28d-11ea-824b-abb90f5d9485.png)
![image](https://user-images.githubusercontent.com/28571284/92624643-5e9ed700-f28d-11ea-8dd4-f950c6e2e2a2.png)

