### PR TITLE
Added an extra check for the remediation procedure

### DIFF
--- a/src/CISDSCResourceGeneration/functions/private/Get-RecommendationFromGPOHash.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Get-RecommendationFromGPOHash.ps1
@@ -43,7 +43,7 @@ function Get-RecommendationFromGPOHash {
             'Registry'{
                 [string]$CorrectionKey = "$($GPOHash['Key'] -replace 'HKLM:','HKEY_LOCAL_MACHINE'):$($GPOHash['ValueName'])"
                 [string]$patternString = "(?i)^($($CorrectionKey))$".replace("\","\\").Replace('*','[*]')
-                [scriptblock]$FilterScript = {($_.AuditProcedure -split "`n") -match $patternString}
+                [scriptblock]$FilterScript = {(($_.AuditProcedure -split "`n") -match $patternString) -or (($_.RemediationProcedure -split "`n") -match $patternString)}
             }
         }
 


### PR DESCRIPTION
- Small enhancement to also check the "remediation procedure" for the registry key when linking GPO to CIS recommendation

- Solution for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/93
