### PR TITLE
adjusted formatting for error export

### DIFF
--- a/src/CISDSCResourceGeneration/functions/private/Export-RecommendationErrors.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Export-RecommendationErrors.ps1
@@ -12,7 +12,16 @@ function Export-RecommendationErrors {
     process {
         if($script:RecommendationErrors){
             [string]$RecommendationErrorsPath = Join-Path -Path $OutputPath -ChildPath 'RecommendationErrors.txt'
-            $script:RecommendationErrors | Out-File -FilePath $RecommendationErrorsPath
+            if(Test-Path -Path $RecommendationErrorsPath){
+                Remove-Item -Path $RecommendationErrorsPath -Force
+            }
+            "$($script:RecommendationErrors.Count) recommendation errors found." | Out-File -FilePath $RecommendationErrorsPath
+
+            $script:RecommendationErrors | ForEach-Object -Process {
+                #Each hash is written seperatly with a dividing line to make it more human readable. Out-Fileing the whole array runs them all together.
+                $_ | Out-File -FilePath $RecommendationErrorsPath -Append
+                '------------------------------------------' | Out-File -FilePath $RecommendationErrorsPath -Append
+            }
         }
     }
 


### PR DESCRIPTION
- Small formatting tweak to make the exported recommendation errors more human readable as this file is only ever ingested by humans. Now there is a dividing line separating the errors found.

![image](https://user-images.githubusercontent.com/28571284/93128835-b1b1c900-f695-11ea-865a-e8ba5c18357c.png)
