### PR TITLE
moved dependency install

### DIFF
--- a/.github/workflows/PublishToGallery.ps1
+++ b/.github/workflows/PublishToGallery.ps1
@@ -1,7 +1,5 @@
 try{
     Set-PSRepository -Name 'PSGallery' -InstallationPolicy 'Trusted'
-    Install-Module -Name 'PSDepend' -Force -SkipPublisherCheck
-    Invoke-PSDepend -Force
     Publish-Module -Path '.\src\CISDSC' -Repository 'PSGallery' -NuGetApiKey $ENV:NuGetApiKey -Force
 }
 catch{

--- a/.github/workflows/publishtogallery.yml
+++ b/.github/workflows/publishtogallery.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: Install-Module -Name 'PSDepend' -Force -SkipPublisherCheck; Invoke-PSDepend -Force
+      shell: pwsh
     - name: Run publish script
       env:
         NuGetApiKey: ${{ secrets.NuGetApiKey }}


### PR DESCRIPTION
This action was having the below exception when installing dependencies so I changed it to install them the same way as the other actions.

![image](https://user-images.githubusercontent.com/28571284/93488056-8dd7c880-f8cb-11ea-985a-09ac5e1faad9.png)
