### PR TITLE
Corrected recommendation ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Corrected values for "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes" across multiple resources. These were previously being pinned to 18.8.7.1.4 with bad values in 18.8.7.1.5
+
 
 ## [1.0.0] - 2020-09-15
 ### Added

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.6.1'
+ModuleVersion = '1.6.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
@@ -2346,47 +2346,42 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         }
     }
     if($ExcludeList -notcontains '18.8.7.1.4' -and $BitLocker){
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (1)" {
+        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions'
             ValueData = 1
             ValueName = 'DenyDeviceClasses'
             ValueType = 'Dword'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (2)" {
+    }
+    if($ExcludeList -notcontains '18.8.7.1.5' -and $BitLocker){
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (1)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{d48179be-ec20-11d1-b6b8-00c04fa372a7}'
             ValueName = '1'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (3)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (2)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{7ebefbc0-3200-11d2-b4c2-00a0C9697d07}'
             ValueName = '2'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (4)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{c06ff265-ae09-48f0-812c-16753d7cba83}'
             ValueName = '3'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (5)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (4)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{6bdd1fc1-810f-11d0-bec7-08002be2092f}'
             ValueName = '4'
             ValueType = 'String'
-        }
-    }
-    if($ExcludeList -notcontains '18.8.7.1.5' -and $BitLocker){
-        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes" {
-            Ensure = 'Absent'
-            Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
-            ValueName = ''
         }
     }
     if($ExcludeList -notcontains '18.8.7.1.6' -and $BitLocker){

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.1'
+ModuleVersion = '1.8.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
@@ -2346,47 +2346,42 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         }
     }
     if($ExcludeList -notcontains '18.8.7.1.4' -and $BitLocker){
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (1)" {
+        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions'
             ValueData = 1
             ValueName = 'DenyDeviceClasses'
             ValueType = 'Dword'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (2)" {
+    }
+    if($ExcludeList -notcontains '18.8.7.1.5' -and $BitLocker){
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (1)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{d48179be-ec20-11d1-b6b8-00c04fa372a7}'
             ValueName = '1'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (3)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (2)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{7ebefbc0-3200-11d2-b4c2-00a0C9697d07}'
             ValueName = '2'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (4)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{c06ff265-ae09-48f0-812c-16753d7cba83}'
             ValueName = '3'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (5)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (4)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{6bdd1fc1-810f-11d0-bec7-08002be2092f}'
             ValueName = '4'
             ValueType = 'String'
-        }
-    }
-    if($ExcludeList -notcontains '18.8.7.1.5' -and $BitLocker){
-        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes" {
-            Ensure = 'Absent'
-            Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
-            ValueName = ''
         }
     }
     if($ExcludeList -notcontains '18.8.7.1.6' -and $BitLocker){

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.9.0'
+ModuleVersion = '1.9.0.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -2353,35 +2353,37 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         }
     }
     if($ExcludeList -notcontains '18.8.7.1.4' -and $BitLocker){
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (1)" {
+        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions'
             ValueData = 1
             ValueName = 'DenyDeviceClasses'
             ValueType = 'Dword'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (2)" {
+    }
+    if($ExcludeList -notcontains '18.8.7.1.5' -and $BitLocker){
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (1)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{d48179be-ec20-11d1-b6b8-00c04fa372a7}'
             ValueName = '1'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (3)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (2)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{7ebefbc0-3200-11d2-b4c2-00a0C9697d07}'
             ValueName = '2'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (4)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{c06ff265-ae09-48f0-812c-16753d7cba83}'
             ValueName = '3'
             ValueType = 'String'
         }
-        Registry "18.8.7.1.4 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes is set to Enabled (5)" {
+        Registry "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes (4)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses'
             ValueData = '{6bdd1fc1-810f-11d0-bec7-08002be2092f}'

--- a/static_corrections/Win10_1809_corrections.csv
+++ b/static_corrections/Win10_1809_corrections.csv
@@ -52,3 +52,7 @@
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate:PauseQualityUpdatesStartTime","18.9.102.1.3","these keys have changed in 1703+ and the documentation is outdated. https://docs.microsoft.com/en-us/windows/deployment/update/waas-configure-wufb"
 "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender Security Center\App and Browser protection:DisallowExploitProtectionOverride","18.9.99.2.1","Benchmark has a typo. 'Windows Defender Security Center' vs 'Windows Security'"
 "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Netbt\Parameters:NodeType","18.5.4.1","Registry key is missing from audit procedure cell of documentation"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:1","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:2","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:3","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:4","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"

--- a/static_corrections/Win10_1909_corrections.csv
+++ b/static_corrections/Win10_1909_corrections.csv
@@ -51,3 +51,7 @@
 "Audit Logoff","17.5.3","GPO specicies success+failure but recommendation is success"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate:PauseFeatureUpdatesStartTime","18.9.102.1.2","these keys have changed in 1703+ and the documentation is outdated. https://docs.microsoft.com/en-us/windows/deployment/update/waas-configure-wufb"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate:PauseQualityUpdatesStartTime","18.9.102.1.3","these keys have changed in 1703+ and the documentation is outdated. https://docs.microsoft.com/en-us/windows/deployment/update/waas-configure-wufb"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:1","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:2","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:3","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:4","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"

--- a/static_corrections/Win10_2004_corrections.csv
+++ b/static_corrections/Win10_2004_corrections.csv
@@ -46,3 +46,7 @@
 "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters:DisabledComponents","18.5.19.2.1","Key is only mentioned in the impact statement","#11366"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\MpEngine:EnableFileHashComputation","18.9.45.5.1","Documentation states the valuename is FileHashComputation","#11367"
 "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\Network Protection:EnableNetworkProtection","18.9.45.4.3.1","Value is only in remediation steps"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:1","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:2","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:3","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:4","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"


### PR DESCRIPTION
- This key was reconfigured due to some weirdness in the Registry.pol file it was generated from. This came to my attention after CIS responded to my ticket on it. The GPO was wanting to delete all values then populated them which lead to some conflicting values being set in some resources and being place in the wrong recommendation for them all.