### PR TITLE
Fixed password length parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Added a parameter for 1.1.4 (L1) Ensure 'Minimum password length' is set to '14 or more character(s)' to the Windows 10 Enterprise 2004 resource as this setting was changed to accept up to 128 characters in this build.
 ## [1.0.0] - 2020-09-15
 ### Added
 - Added DSC resource for Windows 10 Enterprise 1809 based on benchmark v1.6.1

--- a/parameter_validations/Win10_2004_validations.csv
+++ b/parameter_validations/Win10_2004_validations.csv
@@ -1,6 +1,7 @@
 "Recommendation","ValidationString"
 "1.1.2","[ValidateRange(60,999)]"
 "1.1.3","[ValidateRange(1,998)]"
+"1.1.4","[ValidateRange(14,128)]"
 "1.2.1","[ValidateRange(15,99999)]"
 "1.2.2","[ValidateRange(10,999)]"
 "1.2.3","[ValidateRange(15,99999)]"

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -11,6 +11,8 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         [Int32]$112MaximumPasswordAge = 60,
         [ValidateRange(1,998)]
         [Int32]$113MinimumPasswordAge = 1,
+        [ValidateRange(14,128)]
+        [Int32]$114MinimumPasswordLength = 14,
         [ValidateRange(15,99999)]
         [Int32]$121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
@@ -99,7 +101,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     }
     if($ExcludeList -notcontains '1.1.4' -and $LevelOne){
         AccountPolicy "1.1.4 - (L1) Ensure Minimum password length is set to 14 or more character(s)" {
-            Minimum_Password_Length = 14
+            Minimum_Password_Length = $114MinimumPasswordLength
             Name = 'Minimum_Password_Length'
         }
     }


### PR DESCRIPTION
Password length was previously capped at 14 characters making this parameter useless, however with build 2004 this was changed. As long as 'Relax minimum password length limits' is enabled (which is recommendation 1.1.6) this setting now supports up to 128 characters.

https://www.bleepingcomputer.com/news/microsoft/windows-10-version-2004-adds-new-account-password-policies/
![image](https://user-images.githubusercontent.com/28571284/93630154-209d6380-f9af-11ea-9dde-640221ba3ae1.png)
