### PR TITLE
AppHVSIClipboardFileType correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added missing key for HKLM:\SOFTWARE\Policies\Microsoft\AppHVSI:AppHVSIClipboardFileType to Windows 10 Enterprise 2004 18.9.46.5
+
 ### Changed
 - Corrected values for "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes" across multiple resources. These were previously being pinned to 18.8.7.1.4 with bad values in 18.8.7.1.5
 

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -3947,11 +3947,18 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         }
     }
     if($ExcludeList -notcontains '18.9.46.5' -and $NextGenerationWindowsSecurity){
-        Registry "18.9.46.5 - (NG) Ensure Configure Microsoft Defender Application Guard clipboard settings Clipboard behavior setting is set to Enabled Enable clipboard operation from an isolated session to the host" {
+        Registry "18.9.46.5 - (NG) Ensure Configure Microsoft Defender Application Guard clipboard settings Clipboard behavior setting is set to Enabled Enable clipboard operation from an isolated session to the host (1)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\AppHVSI'
             ValueData = 1
             ValueName = 'AppHVSIClipboardSettings'
+            ValueType = 'Dword'
+        }
+        Registry "18.9.46.5 - (NG) Ensure Configure Microsoft Defender Application Guard clipboard settings Clipboard behavior setting is set to Enabled Enable clipboard operation from an isolated session to the host (2)" {
+            Ensure = 'Present'
+            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\AppHVSI'
+            ValueData = 1
+            ValueName = 'AppHVSIClipboardFileType'
             ValueType = 'Dword'
         }
     }

--- a/static_corrections/Win10_2004_corrections.csv
+++ b/static_corrections/Win10_2004_corrections.csv
@@ -50,3 +50,4 @@
 "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:2","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
 "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:3","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
 "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses:4","18.8.7.1.5","key is in a related recommendation 18.8.7.1.5"
+"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI:AppHVSIClipboardFileType","18.9.46.5","These are unmentioned keys impacted by the remediation steps"


### PR DESCRIPTION
- Added missing key for HKLM:\SOFTWARE\Policies\Microsoft\AppHVSI:AppHVSIClipboardFileType to Windows 10 Enterprise 2004 18.9.46.5