### PR TITLE
Added CISService resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added CISService resource. This is a custom resource for managing services that will pass absent or disabled removing the need to add absent services to the ExcludeList of configurations.
 ### Changed
 ### Removed
 

--- a/src/CISDSC/CISDSC.psd1
+++ b/src/CISDSC/CISDSC.psd1
@@ -1,7 +1,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-# RootModule = ''
+RootModule = 'CISDSC.psm1'
 
 # Version number of this module.
 ModuleVersion = '1.0.2'
@@ -77,6 +77,7 @@ RequiredModules = @(
 
 # DSC resources to export from this module
 DscResourcesToExport = @(
+    'CISService',
     'CIS_Microsoft_Windows_10_Enterprise_Release_1809',
     'CIS_Microsoft_Windows_10_Enterprise_Release_1909',
     'CIS_Microsoft_Windows_10_Enterprise_Release_2004'

--- a/src/CISDSC/CISDSC.psm1
+++ b/src/CISDSC/CISDSC.psm1
@@ -1,0 +1,50 @@
+#This resource is used to more accurately reflect the spirit of the CIS benchmarks for services. The recommendations are considered passed if the service is disabled or absent and this is not possible with the standard service resource.
+[DscResource()]
+class CISService
+{
+    [DscProperty(Key)]
+    [string]
+    $Name
+
+    [DscProperty(NotConfigurable)]
+    [string]
+    $StartType
+
+    [DscProperty(NotConfigurable)]
+    [string]
+    $Status
+
+    [CISService]Get()
+    {
+        $Service = $This.GetService()
+        $This.StartType = $Service.StartType
+        $This.Status = $Service.Status
+        return $This
+    }
+
+    [bool]Test()
+    {
+        $Service = $This.GetService()
+        # Is the service abscent or disabled + stopped. Abscent is considered desired state.
+        $Test = ($null -eq $Service -or ($Service.StartType -eq 'Disabled' -and $Service.Status -eq 'Stopped'))
+        return $Test
+    }
+
+    [void]Set()
+    {
+        Stop-Service -Name $This.Name -Force
+        Get-Service -Name $This.Name | Set-Service -StartupType 'Disabled'
+    }
+
+    [Object]GetService()
+    {
+        if($Service = Get-Service -Name $This.Name -ErrorAction SilentlyContinue){
+            $result = $Service
+        }
+        else{
+            $result = $null
+        }
+
+        return $result
+    }
+}

--- a/src/CISDSC/docs/CISService.md
+++ b/src/CISDSC/docs/CISService.md
@@ -1,0 +1,53 @@
+---
+date: 9/30/2020
+keywords: dsc,powershell,configuration,setup,cis,security,service
+title: CISService
+---
+# DSC CISService
+
+> Applies To: Windows PowerShell 5.1 and higher
+
+The **CISService** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to configure services based on CIS guidelines. This differs from the default service resource in that it will consider disabled or absent a pass. This removes the need to exclude non-existent service from your configurations. If the specified service exists it will be stopped and disabled.
+
+## Syntax
+
+```Syntax
+CISService [string] #ResourceName
+{
+    Name = [string]
+    [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
+}
+```
+
+## Properties
+
+|Property |Description |
+|---|---|
+|Name |Name of the service. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](https://docs.microsoft.com/en-us/powershell/scripting/dsc/configurations/runasuser?view=powershell-7).
+
+## Examples
+
+### Example 1: Apply benchmarks with no exclusions
+
+```powershell
+Configuration CISService
+{
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CISService'
+
+    CISService "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
+        Name = 'Browser'
+    }
+}

--- a/test/CISDSC.Tests.ps1
+++ b/test/CISDSC.Tests.ps1
@@ -7,3 +7,28 @@ Describe 'Module Manifest Tests' {
         Test-ModuleManifest -Path $ManifestPath | Should -Not -BeNullOrEmpty
     }
 }
+
+Describe 'Class: CISService' {    
+    InModuleScope -ModuleName 'CISDSC' {
+        It 'Fails a running service' {
+            . "$($PSScriptRoot)\New-PSClassInstance.ps1"
+            $Class = New-PSClassinstance -TypeName 'CISService'
+            $Class.Name = (Get-Service | Where-Object -FilterScript {$_.status -eq 'running'})[0].Name
+            $Class.Test() | Should -Be $False
+        }
+
+        It 'Passes a non-existent service' {
+            . "$($PSScriptRoot)\New-PSClassInstance.ps1"
+            $Class = New-PSClassinstance -TypeName 'CISService'
+            $Class.Name = 'fake-service'
+            $Class.Test() | Should -Be $True
+        }
+
+        It 'Passes a stopped and disabled service'{
+            . "$($PSScriptRoot)\New-PSClassInstance.ps1"
+            $Class = New-PSClassinstance -TypeName 'CISService'
+            $Class.Name = (Get-Service | Where-Object -FilterScript {$_.status -eq 'stopped' -and $_.StartType -eq 'Disabled'})[0].Name
+            $Class.Test() | Should -Be $True
+        }
+    }
+}

--- a/test/New-PSClassInstance.ps1
+++ b/test/New-PSClassInstance.ps1
@@ -1,0 +1,23 @@
+# shamelessly stolen from https://vinojose.wordpress.com/2016/07/19/how-to-use-pester-for-unit-testing-of-class-based-dsc-custom-resource/
+# black magic that lets you test class based resources inside pester
+function New-PSClassInstance
+{
+    param(
+        [Parameter(Mandatory)]
+        [String]$TypeName,
+        [object[]]$ArgumentList = $null
+    )
+
+    $ts = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object Location -eq $null | Foreach-Object -Process {
+        $_.Gettypes()
+    } | Where-Object name -eq $TypeName | Select-Object -Last 1
+    
+    if($ts) {
+        [System.Activator]::CreateInstance($ts,$ArgumentList )
+    }
+    else {
+        $typeException = New-Object TypeLoadException $TypeName
+        $typeException.Data.Add("ArgumentList",$ArgumentList)
+        throw $typeException
+    }
+}


### PR DESCRIPTION
- First PR for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/121

- This resource is used to more accurately reflect the spirit of the CIS benchmarks for services. The recommendations are considered passed if the service is disabled or absent and this is not possible with the standard service resource.

- Subsequent PRs will update existing composite resources to use this as well as updates to the generation module to use it in new resources.