### PR TITLE
Cis service

### DIFF
--- a/.github/workflows/scriptanalyzer.yml
+++ b/.github/workflows/scriptanalyzer.yml
@@ -21,7 +21,7 @@ jobs:
       run: Install-Module -Name 'PSScriptAnalyzer' -Force -SkipPublisherCheck
       shell: pwsh
     - name: Copy to module dir
-      run: Copy-Item -Path '.\src\CISDSC' -DestinationPath "$($pshome)\modules" -Recurse -Force
+      run: Copy-Item -Path '.\src\CISDSC' -Destination "$($pshome)\modules" -Recurse -Force
       shell: pwsh
     - name: ScriptAnalyzer DSCResources
       run: Invoke-ScriptAnalyzer -Path '.\src\CISDSC' -Recurse -EnableExit -SaveDscDependency -ExcludeRule 'PSDSCDscTestsPresent'

--- a/.github/workflows/scriptanalyzer.yml
+++ b/.github/workflows/scriptanalyzer.yml
@@ -20,8 +20,11 @@ jobs:
     - name: Install dependencies
       run: Install-Module -Name 'PSScriptAnalyzer' -Force -SkipPublisherCheck
       shell: pwsh
+    - name: Copy to module dir
+      run: Copy-Item -Path '.\src\CISDSC' -DestinationPath "$($pshome)\modules" -Recurse -Force
+      shell: pwsh
     - name: ScriptAnalyzer DSCResources
-      run: Invoke-ScriptAnalyzer -Path '.\src\CISDSC\DSCResources' -Recurse -EnableExit -SaveDscDependency
+      run: Invoke-ScriptAnalyzer -Path '.\src\CISDSC' -Recurse -EnableExit -SaveDscDependency -ExcludeRule 'PSDSCDscTestsPresent'
       shell: pwsh
     - name: ScriptAnalyzer CISDSCResourceGeneration
       run: Invoke-ScriptAnalyzer -Path '.\src\CISDSCResourceGeneration' -Recurse -EnableExit -SaveDscDependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added CISService resource. This is a custom resource for managing services that will pass absent or disabled removing the need to add absent services to the ExcludeList of configurations.
+- Updated Windows 10 Enterprise 1809,1909, and 2004 to use the new CISService resource.
+
 ### Changed
 ### Removed
 

--- a/src/CISDSC/CISDSC.psm1
+++ b/src/CISDSC/CISDSC.psm1
@@ -25,7 +25,7 @@ class CISService
     [bool]Test()
     {
         $Service = $This.GetService()
-        # Is the service abscent or disabled + stopped. Abscent is considered desired state.
+        # Is the service absent or disabled + stopped. Abscent is considered desired state.
         $Test = ($null -eq $Service -or ($Service.StartType -eq 'Disabled' -and $Service.Status -eq 'Stopped'))
         return $Test
     }

--- a/src/CISDSC/CISDSC.psm1
+++ b/src/CISDSC/CISDSC.psm1
@@ -25,7 +25,7 @@ class CISService
     [bool]Test()
     {
         $Service = $This.GetService()
-        # Is the service absent or disabled + stopped. Abscent is considered desired state.
+        # Is the service absent or disabled? Eiher of these are desired state.
         $Test = ($null -eq $Service -or ($Service.StartType -eq 'Disabled' -and $Service.Status -eq 'Stopped'))
         return $Test
     }

--- a/src/CISDSC/Examples/CISService.ps1
+++ b/src/CISDSC/Examples/CISService.ps1
@@ -1,0 +1,22 @@
+#Requires -module CISDSC
+
+<#
+    .DESCRIPTION
+    CISService will consider disabled or absent to be desired state for a given service. If the service is found not be in desired state it will be stopped and disabled.
+#>
+
+Configuration MyService
+{
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CISService'
+
+    node 'localhost'
+    {
+        CISService 'Disable browser service'
+        {
+            Name = 'browser'
+        }
+    }
+}
+
+MyService
+Start-DscConfiguration -Path '.\MyService'-Verbose -Wait

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
@@ -3,7 +3,7 @@
 <#
     .DESCRIPTION
     Applies CIS Level one benchmarks for Windows 10 build 1809 the no exclusions.
-    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
+    Exclusion documentation can be found in the docs folder of this module.
 #>
 
 Configuration Win10_1809_L1

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
@@ -2,7 +2,8 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Windows 10 build 1809 with the non-standard services excluded.
+    Applies CIS Level one benchmarks for Windows 10 build 1809 the no exclusions.
+    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
 #>
 
 Configuration Win10_1809_L1
@@ -13,16 +14,6 @@ Configuration Win10_1809_L1
     {
         CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CIS Benchmarks'
         {
-            'ExcludeList' = @(
-                '5.6', # IIS Admin Service (IISADMIN)
-                '5.7', # Infrared monitor service (irmon)
-                '5.10',# LxssManager (LxssManager)
-                '5.11',# Microsoft FTP Service (FTPSVC)
-                '5.14',# OpenSSH SSH Server (sshd)
-                '5.28',# Simple TCP/IP Services (simptcp)
-                '5.32',# Web Management Service (WMSvc)
-                '5.40' # World Wide Web Publishing Service (W3SVC)
-            )
             '2315AccountsRenameadministratoraccount' = 'CISAdmin'
             '2316AccountsRenameguestaccount' = 'CISGuest'
             '2376LegalNoticeCaption' = 'Legal Notice'

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
@@ -2,7 +2,8 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Windows 10 build 1809 with the non-standard services excluded.
+    Applies CIS Level one benchmarks for Windows 10 build 1809 with no exclusions.
+    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 
@@ -20,16 +21,6 @@ Configuration Win10_1809_L1_With_LAPS
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CIS Benchmarks' {
-            'ExcludeList' = @(
-                '5.6', # IIS Admin Service (IISADMIN)
-                '5.7', # Infrared monitor service (irmon)
-                '5.10',# LxssManager (LxssManager)
-                '5.11',# Microsoft FTP Service (FTPSVC)
-                '5.14',# OpenSSH SSH Server (sshd)
-                '5.28',# Simple TCP/IP Services (simptcp)
-                '5.32',# Web Management Service (WMSvc)
-                '5.40' # World Wide Web Publishing Service (W3SVC)
-            )
             '2315AccountsRenameadministratoraccount' = 'CISAdmin'
             '2316AccountsRenameguestaccount' = 'CISGuest'
             '2376LegalNoticeCaption' = 'Legal Notice'

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
@@ -3,7 +3,7 @@
 <#
     .DESCRIPTION
     Applies CIS Level one benchmarks for Windows 10 build 1809 with no exclusions.
-    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
+    Exclusion documentation can be found in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
@@ -3,7 +3,7 @@
 <#
     .DESCRIPTION
     Applies CIS Level one benchmarks for Windows 10 build 1909 with no exclusions.
-    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
+    Exclusion documentation can be found in the docs folder of this module.
 #>
 
 Configuration Win10_1909_L1

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
@@ -2,7 +2,8 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Windows 10 build 1909 with the non-standard services excluded.
+    Applies CIS Level one benchmarks for Windows 10 build 1909 with no exclusions.
+    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
 #>
 
 Configuration Win10_1909_L1
@@ -13,16 +14,6 @@ Configuration Win10_1909_L1
     {
         CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CIS Benchmarks'
         {
-            'ExcludeList' = @(
-                '5.6', # IIS Admin Service (IISADMIN)
-                '5.7', # Infrared monitor service (irmon)
-                '5.10',# LxssManager (LxssManager)
-                '5.11',# Microsoft FTP Service (FTPSVC)
-                '5.14',# OpenSSH SSH Server (sshd)
-                '5.28',# Simple TCP/IP Services (simptcp)
-                '5.32',# Web Management Service (WMSvc)
-                '5.40' # World Wide Web Publishing Service (W3SVC)
-            )
             '2315AccountsRenameadministratoraccount' = 'CISAdmin'
             '2316AccountsRenameguestaccount' = 'CISGuest'
             '2376LegalNoticeCaption' = 'Legal Notice'

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
@@ -2,7 +2,8 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Windows 10 build 1909 with the non-standard services excluded.
+    Applies CIS Level one benchmarks for Windows 10 build 1909 with no exclusions.
+    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 
@@ -20,16 +21,6 @@ Configuration Win10_1909_L1_With_LAPS
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CIS Benchmarks' {
-            'ExcludeList' = @(
-                '5.6', # IIS Admin Service (IISADMIN)
-                '5.7', # Infrared monitor service (irmon)
-                '5.10',# LxssManager (LxssManager)
-                '5.11',# Microsoft FTP Service (FTPSVC)
-                '5.14',# OpenSSH SSH Server (sshd)
-                '5.28',# Simple TCP/IP Services (simptcp)
-                '5.32',# Web Management Service (WMSvc)
-                '5.40' # World Wide Web Publishing Service (W3SVC)
-            )
             '2315AccountsRenameadministratoraccount' = 'CISAdmin'
             '2316AccountsRenameguestaccount' = 'CISGuest'
             '2376LegalNoticeCaption' = 'Legal Notice'

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
@@ -3,7 +3,7 @@
 <#
     .DESCRIPTION
     Applies CIS Level one benchmarks for Windows 10 build 1909 with no exclusions.
-    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
+    Exclusion documentation can be found in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
@@ -2,7 +2,8 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Windows 10 build 2004 with the non-standard services excluded.
+    Applies CIS Level one benchmarks for Windows 10 build 2004 with no exclusions.
+    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
 #>
 
 Configuration Win10_2004_L1
@@ -13,17 +14,6 @@ Configuration Win10_2004_L1
     {
         CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CIS Benchmarks'
         {
-            'ExcludeList' = @(
-                '5.6', # IIS Admin Service (IISADMIN)
-                '5.7', # Infrared monitor service (irmon)
-                '5.10',# LxssManager (LxssManager)
-                '5.11',# Microsoft FTP Service (FTPSVC)
-                '5.13',# OpenSSH SSH Server (sshd)
-                '5.27',# Simple TCP/IP Services (simptcp)
-                '5.29',# Special Administration Console Helper (sacsvr)
-                '5.32',# Web Management Service (WMSvc)
-                '5.40' # World Wide Web Publishing Service (W3SVC)
-            )
             '2315AccountsRenameadministratoraccount' = 'CISAdmin'
             '2316AccountsRenameguestaccount' = 'CISGuest'
             '2376LegalNoticeCaption' = 'Legal Notice'

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
@@ -3,7 +3,7 @@
 <#
     .DESCRIPTION
     Applies CIS Level one benchmarks for Windows 10 build 2004 with no exclusions.
-    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
+    Exclusion documentation can be found in the docs folder of this module.
 #>
 
 Configuration Win10_2004_L1

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
@@ -2,7 +2,8 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Windows 10 build 2004 with the non-standard services excluded.
+    Applies CIS Level one benchmarks for Windows 10 build 2004 with no exclusions.
+    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 
@@ -20,17 +21,6 @@ Configuration Win10_2004_L1_With_LAPS
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CIS Benchmarks' {
-            'ExcludeList' = @(
-                '5.6', # IIS Admin Service (IISADMIN)
-                '5.7', # Infrared monitor service (irmon)
-                '5.10',# LxssManager (LxssManager)
-                '5.11',# Microsoft FTP Service (FTPSVC)
-                '5.13',# OpenSSH SSH Server (sshd)
-                '5.27',# Simple TCP/IP Services (simptcp)
-                '5.29',# Special Administration Console Helper (sacsvr)
-                '5.32',# Web Management Service (WMSvc)
-                '5.40' # World Wide Web Publishing Service (W3SVC)
-            )
             '2315AccountsRenameadministratoraccount' = 'CISAdmin'
             '2316AccountsRenameguestaccount' = 'CISGuest'
             '2376LegalNoticeCaption' = 'Legal Notice'

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
@@ -3,7 +3,7 @@
 <#
     .DESCRIPTION
     Applies CIS Level one benchmarks for Windows 10 build 2004 with no exclusions.
-    Exclusion documentation can be found for the applicable documentation in the docs folder of this module.
+    Exclusion documentation can be found in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.6.1.1'
+ModuleVersion = '1.6.1.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
@@ -64,7 +64,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
-    Import-DSCResource -Name 'CISService'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
@@ -64,6 +64,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DSCResource -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
@@ -924,267 +925,223 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         }
     }
     if($ExcludeList -notcontains '5.1' -and $LevelTwo){
-        Service "5.1 - (L2) Ensure Bluetooth Audio Gateway Service (BTAGService) is set to Disabled" {
+        CISService "5.1 - (L2) Ensure Bluetooth Audio Gateway Service (BTAGService) is set to Disabled" {
             Name = 'BTAGService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.2' -and $LevelTwo){
-        Service "5.2 - (L2) Ensure Bluetooth Support Service (bthserv) is set to Disabled" {
+        CISService "5.2 - (L2) Ensure Bluetooth Support Service (bthserv) is set to Disabled" {
             Name = 'bthserv'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.3' -and $LevelOne){
-        Service "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
+        CISService "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
             Name = 'Browser'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.4' -and $LevelTwo){
-        Service "5.4 - (L2) Ensure Downloaded Maps Manager (MapsBroker) is set to Disabled" {
+        CISService "5.4 - (L2) Ensure Downloaded Maps Manager (MapsBroker) is set to Disabled" {
             Name = 'MapsBroker'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.5' -and $LevelTwo){
-        Service "5.5 - (L2) Ensure Geolocation Service (lfsvc) is set to Disabled" {
+        CISService "5.5 - (L2) Ensure Geolocation Service (lfsvc) is set to Disabled" {
             Name = 'lfsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.6' -and $LevelOne){
-        Service "5.6 - (L1) Ensure IIS Admin Service (IISADMIN) is set to Disabled or Not Installed" {
+        CISService "5.6 - (L1) Ensure IIS Admin Service (IISADMIN) is set to Disabled or Not Installed" {
             Name = 'IISADMIN'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.7' -and $LevelOne){
-        Service "5.7 - (L1) Ensure Infrared monitor service (irmon) is set to Disabled" {
+        CISService "5.7 - (L1) Ensure Infrared monitor service (irmon) is set to Disabled" {
             Name = 'irmon'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.8' -and $LevelOne){
-        Service "5.8 - (L1) Ensure Internet Connection Sharing (ICS) (SharedAccess) is set to Disabled" {
+        CISService "5.8 - (L1) Ensure Internet Connection Sharing (ICS) (SharedAccess) is set to Disabled" {
             Name = 'SharedAccess'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.9' -and $LevelTwo){
-        Service "5.9 - (L2) Ensure Link-Layer Topology Discovery Mapper (lltdsvc) is set to Disabled" {
+        CISService "5.9 - (L2) Ensure Link-Layer Topology Discovery Mapper (lltdsvc) is set to Disabled" {
             Name = 'lltdsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.10' -and $LevelOne){
-        Service "5.10 - (L1) Ensure LxssManager (LxssManager) is set to Disabled or Not Installed" {
+        CISService "5.10 - (L1) Ensure LxssManager (LxssManager) is set to Disabled or Not Installed" {
             Name = 'LxssManager'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.11' -and $LevelOne){
-        Service "5.11 - (L1) Ensure Microsoft FTP Service (FTPSVC) is set to Disabled or Not Installed" {
+        CISService "5.11 - (L1) Ensure Microsoft FTP Service (FTPSVC) is set to Disabled or Not Installed" {
             Name = 'ftpsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.12' -and $LevelTwo){
-        Service "5.12 - (L2) Ensure Microsoft iSCSI Initiator Service (MSiSCSI) is set to Disabled" {
+        CISService "5.12 - (L2) Ensure Microsoft iSCSI Initiator Service (MSiSCSI) is set to Disabled" {
             Name = 'MSiSCSI'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.13' -and $LevelTwo){
-        Service "5.13 - (L2) Ensure Microsoft Store Install Service (InstallService) is set to Disabled" {
+        CISService "5.13 - (L2) Ensure Microsoft Store Install Service (InstallService) is set to Disabled" {
             Name = 'InstallService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.14' -and $LevelOne){
-        Service "5.14 - (L1) Ensure OpenSSH SSH Server (sshd) is set to Disabled or Not Installed" {
+        CISService "5.14 - (L1) Ensure OpenSSH SSH Server (sshd) is set to Disabled or Not Installed" {
             Name = 'sshd'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.15' -and $LevelTwo){
-        Service "5.15 - (L2) Ensure Peer Name Resolution Protocol (PNRPsvc) is set to Disabled" {
+        CISService "5.15 - (L2) Ensure Peer Name Resolution Protocol (PNRPsvc) is set to Disabled" {
             Name = 'PNRPsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.16' -and $LevelTwo){
-        Service "5.16 - (L2) Ensure Peer Networking Grouping (p2psvc) is set to Disabled" {
+        CISService "5.16 - (L2) Ensure Peer Networking Grouping (p2psvc) is set to Disabled" {
             Name = 'p2psvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.17' -and $LevelTwo){
-        Service "5.17 - (L2) Ensure Peer Networking Identity Manager (p2pimsvc) is set to Disabled" {
+        CISService "5.17 - (L2) Ensure Peer Networking Identity Manager (p2pimsvc) is set to Disabled" {
             Name = 'p2pimsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.18' -and $LevelTwo){
-        Service "5.18 - (L2) Ensure PNRP Machine Name Publication Service (PNRPAutoReg) is set to Disabled" {
+        CISService "5.18 - (L2) Ensure PNRP Machine Name Publication Service (PNRPAutoReg) is set to Disabled" {
             Name = 'PNRPAutoReg'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.19' -and $LevelTwo){
-        Service "5.19 - (L2) Ensure Problem Reports and Solutions Control Panel Support (wercplsupport) is set to Disabled" {
+        CISService "5.19 - (L2) Ensure Problem Reports and Solutions Control Panel Support (wercplsupport) is set to Disabled" {
             Name = 'wercplsupport'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.20' -and $LevelTwo){
-        Service "5.20 - (L2) Ensure Remote Access Auto Connection Manager (RasAuto) is set to Disabled" {
+        CISService "5.20 - (L2) Ensure Remote Access Auto Connection Manager (RasAuto) is set to Disabled" {
             Name = 'RasAuto'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.21' -and $LevelTwo){
-        Service "5.21 - (L2) Ensure Remote Desktop Configuration (SessionEnv) is set to Disabled" {
+        CISService "5.21 - (L2) Ensure Remote Desktop Configuration (SessionEnv) is set to Disabled" {
             Name = 'SessionEnv'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.22' -and $LevelTwo){
-        Service "5.22 - (L2) Ensure Remote Desktop Services (TermService) is set to Disabled" {
+        CISService "5.22 - (L2) Ensure Remote Desktop Services (TermService) is set to Disabled" {
             Name = 'TermService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.23' -and $LevelTwo){
-        Service "5.23 - (L2) Ensure Remote Desktop Services UserMode Port Redirector (UmRdpService) is set to Disabled" {
+        CISService "5.23 - (L2) Ensure Remote Desktop Services UserMode Port Redirector (UmRdpService) is set to Disabled" {
             Name = 'UmRdpService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.24' -and $LevelOne){
-        Service "5.24 - (L1) Ensure Remote Procedure Call (RPC) Locator (RpcLocator) is set to Disabled" {
+        CISService "5.24 - (L1) Ensure Remote Procedure Call (RPC) Locator (RpcLocator) is set to Disabled" {
             Name = 'RpcLocator'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.25' -and $LevelTwo){
-        Service "5.25 - (L2) Ensure Remote Registry (RemoteRegistry) is set to Disabled" {
+        CISService "5.25 - (L2) Ensure Remote Registry (RemoteRegistry) is set to Disabled" {
             Name = 'RemoteRegistry'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.26' -and $LevelOne){
-        Service "5.26 - (L1) Ensure Routing and Remote Access (RemoteAccess) is set to Disabled" {
+        CISService "5.26 - (L1) Ensure Routing and Remote Access (RemoteAccess) is set to Disabled" {
             Name = 'RemoteAccess'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.27' -and $LevelTwo){
-        Service "5.27 - (L2) Ensure Server (LanmanServer) is set to Disabled" {
+        CISService "5.27 - (L2) Ensure Server (LanmanServer) is set to Disabled" {
             Name = 'LanmanServer'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.28' -and $LevelOne){
-        Service "5.28 - (L1) Ensure Simple TCPIP Services (simptcp) is set to Disabled or Not Installed" {
+        CISService "5.28 - (L1) Ensure Simple TCPIP Services (simptcp) is set to Disabled or Not Installed" {
             Name = 'simptcp'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.29' -and $LevelTwo){
-        Service "5.29 - (L2) Ensure SNMP Service (SNMP) is set to Disabled or Not Installed" {
+        CISService "5.29 - (L2) Ensure SNMP Service (SNMP) is set to Disabled or Not Installed" {
             Name = 'SNMP'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.30' -and $LevelOne){
-        Service "5.30 - (L1) Ensure SSDP Discovery (SSDPSRV) is set to Disabled" {
+        CISService "5.30 - (L1) Ensure SSDP Discovery (SSDPSRV) is set to Disabled" {
             Name = 'SSDPSRV'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.31' -and $LevelOne){
-        Service "5.31 - (L1) Ensure UPnP Device Host (upnphost) is set to Disabled" {
+        CISService "5.31 - (L1) Ensure UPnP Device Host (upnphost) is set to Disabled" {
             Name = 'upnphost'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.32' -and $LevelOne){
-        Service "5.32 - (L1) Ensure Web Management Service (WMSvc) is set to Disabled or Not Installed" {
+        CISService "5.32 - (L1) Ensure Web Management Service (WMSvc) is set to Disabled or Not Installed" {
             Name = 'WMSVC'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.33' -and $LevelTwo){
-        Service "5.33 - (L2) Ensure Windows Error Reporting Service (WerSvc) is set to Disabled" {
+        CISService "5.33 - (L2) Ensure Windows Error Reporting Service (WerSvc) is set to Disabled" {
             Name = 'WerSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.34' -and $LevelTwo){
-        Service "5.34 - (L2) Ensure Windows Event Collector (Wecsvc) is set to Disabled" {
+        CISService "5.34 - (L2) Ensure Windows Event Collector (Wecsvc) is set to Disabled" {
             Name = 'Wecsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.35' -and $LevelOne){
-        Service "5.35 - (L1) Ensure Windows Media Player Network Sharing Service (WMPNetworkSvc) is set to Disabled or Not Installed" {
+        CISService "5.35 - (L1) Ensure Windows Media Player Network Sharing Service (WMPNetworkSvc) is set to Disabled or Not Installed" {
             Name = 'WMPNetworkSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.36' -and $LevelOne){
-        Service "5.36 - (L1) Ensure Windows Mobile Hotspot Service (icssvc) is set to Disabled" {
+        CISService "5.36 - (L1) Ensure Windows Mobile Hotspot Service (icssvc) is set to Disabled" {
             Name = 'icssvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.37' -and $LevelTwo){
-        Service "5.37 - (L2) Ensure Windows Push Notifications System Service (WpnService) is set to Disabled" {
+        CISService "5.37 - (L2) Ensure Windows Push Notifications System Service (WpnService) is set to Disabled" {
             Name = 'WpnService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.38' -and $LevelTwo){
-        Service "5.38 - (L2) Ensure Windows PushToInstall Service (PushToInstall) is set to Disabled" {
+        CISService "5.38 - (L2) Ensure Windows PushToInstall Service (PushToInstall) is set to Disabled" {
             Name = 'PushToInstall'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.39' -and $LevelTwo){
-        Service "5.39 - (L2) Ensure Windows Remote Management (WS-Management) (WinRM) is set to Disabled" {
+        CISService "5.39 - (L2) Ensure Windows Remote Management (WS-Management) (WinRM) is set to Disabled" {
             Name = 'WinRM'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.40' -and $LevelOne){
-        Service "5.40 - (L1) Ensure World Wide Web Publishing Service (W3SVC) is set to Disabled or Not Installed" {
+        CISService "5.40 - (L1) Ensure World Wide Web Publishing Service (W3SVC) is set to Disabled or Not Installed" {
             Name = 'W3SVC'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.41' -and $LevelOne){
-        Service "5.41 - (L1) Ensure Xbox Accessory Management Service (XboxGipSvc) is set to Disabled" {
+        CISService "5.41 - (L1) Ensure Xbox Accessory Management Service (XboxGipSvc) is set to Disabled" {
             Name = 'XboxGipSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.42' -and $LevelOne){
-        Service "5.42 - (L1) Ensure Xbox Live Auth Manager (XblAuthManager) is set to Disabled" {
+        CISService "5.42 - (L1) Ensure Xbox Live Auth Manager (XblAuthManager) is set to Disabled" {
             Name = 'XblAuthManager'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.43' -and $LevelOne){
-        Service "5.43 - (L1) Ensure Xbox Live Game Save (XblGameSave) is set to Disabled" {
+        CISService "5.43 - (L1) Ensure Xbox Live Game Save (XblGameSave) is set to Disabled" {
             Name = 'XblGameSave'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.44' -and $LevelOne){
-        Service "5.44 - (L1) Ensure Xbox Live Networking Service (XboxNetApiSvc) is set to Disabled" {
+        CISService "5.44 - (L1) Ensure Xbox Live Networking Service (XboxNetApiSvc) is set to Disabled" {
             Name = 'XboxNetApiSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '9.1.1' -and $LevelOne){

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.1.1'
+ModuleVersion = '1.8.1.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
@@ -64,6 +64,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DSCResource -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
@@ -924,267 +925,223 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         }
     }
     if($ExcludeList -notcontains '5.1' -and $LevelTwo){
-        Service "5.1 - (L2) Ensure Bluetooth Audio Gateway Service (BTAGService) is set to Disabled" {
+        CISService "5.1 - (L2) Ensure Bluetooth Audio Gateway Service (BTAGService) is set to Disabled" {
             Name = 'BTAGService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.2' -and $LevelTwo){
-        Service "5.2 - (L2) Ensure Bluetooth Support Service (bthserv) is set to Disabled" {
+        CISService "5.2 - (L2) Ensure Bluetooth Support Service (bthserv) is set to Disabled" {
             Name = 'bthserv'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.3' -and $LevelOne){
-        Service "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
+        CISService "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
             Name = 'Browser'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.4' -and $LevelTwo){
-        Service "5.4 - (L2) Ensure Downloaded Maps Manager (MapsBroker) is set to Disabled" {
+        CISService "5.4 - (L2) Ensure Downloaded Maps Manager (MapsBroker) is set to Disabled" {
             Name = 'MapsBroker'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.5' -and $LevelTwo){
-        Service "5.5 - (L2) Ensure Geolocation Service (lfsvc) is set to Disabled" {
+        CISService "5.5 - (L2) Ensure Geolocation Service (lfsvc) is set to Disabled" {
             Name = 'lfsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.6' -and $LevelOne){
-        Service "5.6 - (L1) Ensure IIS Admin Service (IISADMIN) is set to Disabled or Not Installed" {
+        CISService "5.6 - (L1) Ensure IIS Admin Service (IISADMIN) is set to Disabled or Not Installed" {
             Name = 'IISADMIN'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.7' -and $LevelOne){
-        Service "5.7 - (L1) Ensure Infrared monitor service (irmon) is set to Disabled or Not Installed" {
+        CISService "5.7 - (L1) Ensure Infrared monitor service (irmon) is set to Disabled or Not Installed" {
             Name = 'irmon'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.8' -and $LevelOne){
-        Service "5.8 - (L1) Ensure Internet Connection Sharing (ICS) (SharedAccess) is set to Disabled" {
+        CISService "5.8 - (L1) Ensure Internet Connection Sharing (ICS) (SharedAccess) is set to Disabled" {
             Name = 'SharedAccess'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.9' -and $LevelTwo){
-        Service "5.9 - (L2) Ensure Link-Layer Topology Discovery Mapper (lltdsvc) is set to Disabled" {
+        CISService "5.9 - (L2) Ensure Link-Layer Topology Discovery Mapper (lltdsvc) is set to Disabled" {
             Name = 'lltdsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.10' -and $LevelOne){
-        Service "5.10 - (L1) Ensure LxssManager (LxssManager) is set to Disabled or Not Installed" {
+        CISService "5.10 - (L1) Ensure LxssManager (LxssManager) is set to Disabled or Not Installed" {
             Name = 'LxssManager'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.11' -and $LevelOne){
-        Service "5.11 - (L1) Ensure Microsoft FTP Service (FTPSVC) is set to Disabled or Not Installed" {
+        CISService "5.11 - (L1) Ensure Microsoft FTP Service (FTPSVC) is set to Disabled or Not Installed" {
             Name = 'ftpsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.12' -and $LevelTwo){
-        Service "5.12 - (L2) Ensure Microsoft iSCSI Initiator Service (MSiSCSI) is set to Disabled" {
+        CISService "5.12 - (L2) Ensure Microsoft iSCSI Initiator Service (MSiSCSI) is set to Disabled" {
             Name = 'MSiSCSI'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.13' -and $LevelTwo){
-        Service "5.13 - (L2) Ensure Microsoft Store Install Service (InstallService) is set to Disabled" {
+        CISService "5.13 - (L2) Ensure Microsoft Store Install Service (InstallService) is set to Disabled" {
             Name = 'InstallService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.14' -and $LevelOne){
-        Service "5.14 - (L1) Ensure OpenSSH SSH Server (sshd) is set to Disabled or Not Installed" {
+        CISService "5.14 - (L1) Ensure OpenSSH SSH Server (sshd) is set to Disabled or Not Installed" {
             Name = 'sshd'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.15' -and $LevelTwo){
-        Service "5.15 - (L2) Ensure Peer Name Resolution Protocol (PNRPsvc) is set to Disabled" {
+        CISService "5.15 - (L2) Ensure Peer Name Resolution Protocol (PNRPsvc) is set to Disabled" {
             Name = 'PNRPsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.16' -and $LevelTwo){
-        Service "5.16 - (L2) Ensure Peer Networking Grouping (p2psvc) is set to Disabled" {
+        CISService "5.16 - (L2) Ensure Peer Networking Grouping (p2psvc) is set to Disabled" {
             Name = 'p2psvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.17' -and $LevelTwo){
-        Service "5.17 - (L2) Ensure Peer Networking Identity Manager (p2pimsvc) is set to Disabled" {
+        CISService "5.17 - (L2) Ensure Peer Networking Identity Manager (p2pimsvc) is set to Disabled" {
             Name = 'p2pimsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.18' -and $LevelTwo){
-        Service "5.18 - (L2) Ensure PNRP Machine Name Publication Service (PNRPAutoReg) is set to Disabled" {
+        CISService "5.18 - (L2) Ensure PNRP Machine Name Publication Service (PNRPAutoReg) is set to Disabled" {
             Name = 'PNRPAutoReg'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.19' -and $LevelTwo){
-        Service "5.19 - (L2) Ensure Problem Reports and Solutions Control Panel Support (wercplsupport) is set to Disabled" {
+        CISService "5.19 - (L2) Ensure Problem Reports and Solutions Control Panel Support (wercplsupport) is set to Disabled" {
             Name = 'wercplsupport'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.20' -and $LevelTwo){
-        Service "5.20 - (L2) Ensure Remote Access Auto Connection Manager (RasAuto) is set to Disabled" {
+        CISService "5.20 - (L2) Ensure Remote Access Auto Connection Manager (RasAuto) is set to Disabled" {
             Name = 'RasAuto'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.21' -and $LevelTwo){
-        Service "5.21 - (L2) Ensure Remote Desktop Configuration (SessionEnv) is set to Disabled" {
+        CISService "5.21 - (L2) Ensure Remote Desktop Configuration (SessionEnv) is set to Disabled" {
             Name = 'SessionEnv'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.22' -and $LevelTwo){
-        Service "5.22 - (L2) Ensure Remote Desktop Services (TermService) is set to Disabled" {
+        CISService "5.22 - (L2) Ensure Remote Desktop Services (TermService) is set to Disabled" {
             Name = 'TermService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.23' -and $LevelTwo){
-        Service "5.23 - (L2) Ensure Remote Desktop Services UserMode Port Redirector (UmRdpService) is set to Disabled" {
+        CISService "5.23 - (L2) Ensure Remote Desktop Services UserMode Port Redirector (UmRdpService) is set to Disabled" {
             Name = 'UmRdpService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.24' -and $LevelOne){
-        Service "5.24 - (L1) Ensure Remote Procedure Call (RPC) Locator (RpcLocator) is set to Disabled" {
+        CISService "5.24 - (L1) Ensure Remote Procedure Call (RPC) Locator (RpcLocator) is set to Disabled" {
             Name = 'RpcLocator'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.25' -and $LevelTwo){
-        Service "5.25 - (L2) Ensure Remote Registry (RemoteRegistry) is set to Disabled" {
+        CISService "5.25 - (L2) Ensure Remote Registry (RemoteRegistry) is set to Disabled" {
             Name = 'RemoteRegistry'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.26' -and $LevelOne){
-        Service "5.26 - (L1) Ensure Routing and Remote Access (RemoteAccess) is set to Disabled" {
+        CISService "5.26 - (L1) Ensure Routing and Remote Access (RemoteAccess) is set to Disabled" {
             Name = 'RemoteAccess'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.27' -and $LevelTwo){
-        Service "5.27 - (L2) Ensure Server (LanmanServer) is set to Disabled" {
+        CISService "5.27 - (L2) Ensure Server (LanmanServer) is set to Disabled" {
             Name = 'LanmanServer'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.28' -and $LevelOne){
-        Service "5.28 - (L1) Ensure Simple TCPIP Services (simptcp) is set to Disabled or Not Installed" {
+        CISService "5.28 - (L1) Ensure Simple TCPIP Services (simptcp) is set to Disabled or Not Installed" {
             Name = 'simptcp'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.29' -and $LevelTwo){
-        Service "5.29 - (L2) Ensure SNMP Service (SNMP) is set to Disabled or Not Installed" {
+        CISService "5.29 - (L2) Ensure SNMP Service (SNMP) is set to Disabled or Not Installed" {
             Name = 'SNMP'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.30' -and $LevelOne){
-        Service "5.30 - (L1) Ensure SSDP Discovery (SSDPSRV) is set to Disabled" {
+        CISService "5.30 - (L1) Ensure SSDP Discovery (SSDPSRV) is set to Disabled" {
             Name = 'SSDPSRV'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.31' -and $LevelOne){
-        Service "5.31 - (L1) Ensure UPnP Device Host (upnphost) is set to Disabled" {
+        CISService "5.31 - (L1) Ensure UPnP Device Host (upnphost) is set to Disabled" {
             Name = 'upnphost'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.32' -and $LevelOne){
-        Service "5.32 - (L1) Ensure Web Management Service (WMSvc) is set to Disabled or Not Installed" {
+        CISService "5.32 - (L1) Ensure Web Management Service (WMSvc) is set to Disabled or Not Installed" {
             Name = 'WMSVC'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.33' -and $LevelTwo){
-        Service "5.33 - (L2) Ensure Windows Error Reporting Service (WerSvc) is set to Disabled" {
+        CISService "5.33 - (L2) Ensure Windows Error Reporting Service (WerSvc) is set to Disabled" {
             Name = 'WerSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.34' -and $LevelTwo){
-        Service "5.34 - (L2) Ensure Windows Event Collector (Wecsvc) is set to Disabled" {
+        CISService "5.34 - (L2) Ensure Windows Event Collector (Wecsvc) is set to Disabled" {
             Name = 'Wecsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.35' -and $LevelOne){
-        Service "5.35 - (L1) Ensure Windows Media Player Network Sharing Service (WMPNetworkSvc) is set to Disabled or Not Installed" {
+        CISService "5.35 - (L1) Ensure Windows Media Player Network Sharing Service (WMPNetworkSvc) is set to Disabled or Not Installed" {
             Name = 'WMPNetworkSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.36' -and $LevelOne){
-        Service "5.36 - (L1) Ensure Windows Mobile Hotspot Service (icssvc) is set to Disabled" {
+        CISService "5.36 - (L1) Ensure Windows Mobile Hotspot Service (icssvc) is set to Disabled" {
             Name = 'icssvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.37' -and $LevelTwo){
-        Service "5.37 - (L2) Ensure Windows Push Notifications System Service (WpnService) is set to Disabled" {
+        CISService "5.37 - (L2) Ensure Windows Push Notifications System Service (WpnService) is set to Disabled" {
             Name = 'WpnService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.38' -and $LevelTwo){
-        Service "5.38 - (L2) Ensure Windows PushToInstall Service (PushToInstall) is set to Disabled" {
+        CISService "5.38 - (L2) Ensure Windows PushToInstall Service (PushToInstall) is set to Disabled" {
             Name = 'PushToInstall'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.39' -and $LevelTwo){
-        Service "5.39 - (L2) Ensure Windows Remote Management (WS-Management) (WinRM) is set to Disabled" {
+        CISService "5.39 - (L2) Ensure Windows Remote Management (WS-Management) (WinRM) is set to Disabled" {
             Name = 'WinRM'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.40' -and $LevelOne){
-        Service "5.40 - (L1) Ensure World Wide Web Publishing Service (W3SVC) is set to Disabled or Not Installed" {
+        CISService "5.40 - (L1) Ensure World Wide Web Publishing Service (W3SVC) is set to Disabled or Not Installed" {
             Name = 'W3SVC'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.41' -and $LevelOne){
-        Service "5.41 - (L1) Ensure Xbox Accessory Management Service (XboxGipSvc) is set to Disabled" {
+        CISService "5.41 - (L1) Ensure Xbox Accessory Management Service (XboxGipSvc) is set to Disabled" {
             Name = 'XboxGipSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.42' -and $LevelOne){
-        Service "5.42 - (L1) Ensure Xbox Live Auth Manager (XblAuthManager) is set to Disabled" {
+        CISService "5.42 - (L1) Ensure Xbox Live Auth Manager (XblAuthManager) is set to Disabled" {
             Name = 'XblAuthManager'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.43' -and $LevelOne){
-        Service "5.43 - (L1) Ensure Xbox Live Game Save (XblGameSave) is set to Disabled" {
+        CISService "5.43 - (L1) Ensure Xbox Live Game Save (XblGameSave) is set to Disabled" {
             Name = 'XblGameSave'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.44' -and $LevelOne){
-        Service "5.44 - (L1) Ensure Xbox Live Networking Service (XboxNetApiSvc) is set to Disabled" {
+        CISService "5.44 - (L1) Ensure Xbox Live Networking Service (XboxNetApiSvc) is set to Disabled" {
             Name = 'XboxNetApiSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '9.1.1' -and $LevelOne){

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
@@ -64,7 +64,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
-    Import-DSCResource -Name 'CISService'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.9.0.2'
+ModuleVersion = '1.9.0.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -66,6 +66,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DSCResource -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
@@ -934,267 +935,223 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         }
     }
     if($ExcludeList -notcontains '5.1' -and $LevelTwo){
-        Service "5.1 - (L2) Ensure Bluetooth Audio Gateway Service (BTAGService) is set to Disabled" {
+        CISService "5.1 - (L2) Ensure Bluetooth Audio Gateway Service (BTAGService) is set to Disabled" {
             Name = 'BTAGService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.2' -and $LevelTwo){
-        Service "5.2 - (L2) Ensure Bluetooth Support Service (bthserv) is set to Disabled" {
+        CISService "5.2 - (L2) Ensure Bluetooth Support Service (bthserv) is set to Disabled" {
             Name = 'bthserv'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.3' -and $LevelOne){
-        Service "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
+        CISService "5.3 - (L1) Ensure Computer Browser (Browser) is set to Disabled or Not Installed" {
             Name = 'Browser'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.4' -and $LevelTwo){
-        Service "5.4 - (L2) Ensure Downloaded Maps Manager (MapsBroker) is set to Disabled" {
+        CISService "5.4 - (L2) Ensure Downloaded Maps Manager (MapsBroker) is set to Disabled" {
             Name = 'MapsBroker'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.5' -and $LevelTwo){
-        Service "5.5 - (L2) Ensure Geolocation Service (lfsvc) is set to Disabled" {
+        CISService "5.5 - (L2) Ensure Geolocation Service (lfsvc) is set to Disabled" {
             Name = 'lfsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.6' -and $LevelOne){
-        Service "5.6 - (L1) Ensure IIS Admin Service (IISADMIN) is set to Disabled or Not Installed" {
+        CISService "5.6 - (L1) Ensure IIS Admin Service (IISADMIN) is set to Disabled or Not Installed" {
             Name = 'IISADMIN'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.7' -and $LevelOne){
-        Service "5.7 - (L1) Ensure Infrared monitor service (irmon) is set to Disabled or Not Installed" {
+        CISService "5.7 - (L1) Ensure Infrared monitor service (irmon) is set to Disabled or Not Installed" {
             Name = 'irmon'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.8' -and $LevelOne){
-        Service "5.8 - (L1) Ensure Internet Connection Sharing (ICS) (SharedAccess) is set to Disabled" {
+        CISService "5.8 - (L1) Ensure Internet Connection Sharing (ICS) (SharedAccess) is set to Disabled" {
             Name = 'SharedAccess'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.9' -and $LevelTwo){
-        Service "5.9 - (L2) Ensure Link-Layer Topology Discovery Mapper (lltdsvc) is set to Disabled" {
+        CISService "5.9 - (L2) Ensure Link-Layer Topology Discovery Mapper (lltdsvc) is set to Disabled" {
             Name = 'lltdsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.10' -and $LevelOne){
-        Service "5.10 - (L1) Ensure LxssManager (LxssManager) is set to Disabled or Not Installed" {
+        CISService "5.10 - (L1) Ensure LxssManager (LxssManager) is set to Disabled or Not Installed" {
             Name = 'LxssManager'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.11' -and $LevelOne){
-        Service "5.11 - (L1) Ensure Microsoft FTP Service (FTPSVC) is set to Disabled or Not Installed" {
+        CISService "5.11 - (L1) Ensure Microsoft FTP Service (FTPSVC) is set to Disabled or Not Installed" {
             Name = 'ftpsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.12' -and $LevelTwo){
-        Service "5.12 - (L2) Ensure Microsoft iSCSI Initiator Service (MSiSCSI) is set to Disabled" {
+        CISService "5.12 - (L2) Ensure Microsoft iSCSI Initiator Service (MSiSCSI) is set to Disabled" {
             Name = 'MSiSCSI'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.13' -and $LevelOne){
-        Service "5.13 - (L1) Ensure OpenSSH SSH Server (sshd) is set to Disabled or Not Installed" {
+        CISService "5.13 - (L1) Ensure OpenSSH SSH Server (sshd) is set to Disabled or Not Installed" {
             Name = 'sshd'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.14' -and $LevelTwo){
-        Service "5.14 - (L2) Ensure Peer Name Resolution Protocol (PNRPsvc) is set to Disabled" {
+        CISService "5.14 - (L2) Ensure Peer Name Resolution Protocol (PNRPsvc) is set to Disabled" {
             Name = 'PNRPsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.15' -and $LevelTwo){
-        Service "5.15 - (L2) Ensure Peer Networking Grouping (p2psvc) is set to Disabled" {
+        CISService "5.15 - (L2) Ensure Peer Networking Grouping (p2psvc) is set to Disabled" {
             Name = 'p2psvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.16' -and $LevelTwo){
-        Service "5.16 - (L2) Ensure Peer Networking Identity Manager (p2pimsvc) is set to Disabled" {
+        CISService "5.16 - (L2) Ensure Peer Networking Identity Manager (p2pimsvc) is set to Disabled" {
             Name = 'p2pimsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.17' -and $LevelTwo){
-        Service "5.17 - (L2) Ensure PNRP Machine Name Publication Service (PNRPAutoReg) is set to Disabled" {
+        CISService "5.17 - (L2) Ensure PNRP Machine Name Publication Service (PNRPAutoReg) is set to Disabled" {
             Name = 'PNRPAutoReg'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.18' -and $LevelTwo){
-        Service "5.18 - (L2) Ensure Problem Reports and Solutions Control Panel Support (wercplsupport) is set to Disabled" {
+        CISService "5.18 - (L2) Ensure Problem Reports and Solutions Control Panel Support (wercplsupport) is set to Disabled" {
             Name = 'wercplsupport'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.19' -and $LevelTwo){
-        Service "5.19 - (L2) Ensure Remote Access Auto Connection Manager (RasAuto) is set to Disabled" {
+        CISService "5.19 - (L2) Ensure Remote Access Auto Connection Manager (RasAuto) is set to Disabled" {
             Name = 'RasAuto'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.20' -and $LevelTwo){
-        Service "5.20 - (L2) Ensure Remote Desktop Configuration (SessionEnv) is set to Disabled" {
+        CISService "5.20 - (L2) Ensure Remote Desktop Configuration (SessionEnv) is set to Disabled" {
             Name = 'SessionEnv'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.21' -and $LevelTwo){
-        Service "5.21 - (L2) Ensure Remote Desktop Services (TermService) is set to Disabled" {
+        CISService "5.21 - (L2) Ensure Remote Desktop Services (TermService) is set to Disabled" {
             Name = 'TermService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.22' -and $LevelTwo){
-        Service "5.22 - (L2) Ensure Remote Desktop Services UserMode Port Redirector (UmRdpService) is set to Disabled" {
+        CISService "5.22 - (L2) Ensure Remote Desktop Services UserMode Port Redirector (UmRdpService) is set to Disabled" {
             Name = 'UmRdpService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.23' -and $LevelOne){
-        Service "5.23 - (L1) Ensure Remote Procedure Call (RPC) Locator (RpcLocator) is set to Disabled" {
+        CISService "5.23 - (L1) Ensure Remote Procedure Call (RPC) Locator (RpcLocator) is set to Disabled" {
             Name = 'RpcLocator'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.24' -and $LevelTwo){
-        Service "5.24 - (L2) Ensure Remote Registry (RemoteRegistry) is set to Disabled" {
+        CISService "5.24 - (L2) Ensure Remote Registry (RemoteRegistry) is set to Disabled" {
             Name = 'RemoteRegistry'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.25' -and $LevelOne){
-        Service "5.25 - (L1) Ensure Routing and Remote Access (RemoteAccess) is set to Disabled" {
+        CISService "5.25 - (L1) Ensure Routing and Remote Access (RemoteAccess) is set to Disabled" {
             Name = 'RemoteAccess'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.26' -and $LevelTwo){
-        Service "5.26 - (L2) Ensure Server (LanmanServer) is set to Disabled" {
+        CISService "5.26 - (L2) Ensure Server (LanmanServer) is set to Disabled" {
             Name = 'LanmanServer'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.27' -and $LevelOne){
-        Service "5.27 - (L1) Ensure Simple TCPIP Services (simptcp) is set to Disabled or Not Installed" {
+        CISService "5.27 - (L1) Ensure Simple TCPIP Services (simptcp) is set to Disabled or Not Installed" {
             Name = 'simptcp'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.28' -and $LevelTwo){
-        Service "5.28 - (L2) Ensure SNMP Service (SNMP) is set to Disabled or Not Installed" {
+        CISService "5.28 - (L2) Ensure SNMP Service (SNMP) is set to Disabled or Not Installed" {
             Name = 'SNMP'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.29' -and $LevelOne){
-        Service "5.29 - (L1) Ensure Special Administration Console Helper (sacsvr) is set to Disabled or Not Installed" {
+        CISService "5.29 - (L1) Ensure Special Administration Console Helper (sacsvr) is set to Disabled or Not Installed" {
             Name = 'sacsvr'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.30' -and $LevelOne){
-        Service "5.30 - (L1) Ensure SSDP Discovery (SSDPSRV) is set to Disabled" {
+        CISService "5.30 - (L1) Ensure SSDP Discovery (SSDPSRV) is set to Disabled" {
             Name = 'SSDPSRV'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.31' -and $LevelOne){
-        Service "5.31 - (L1) Ensure UPnP Device Host (upnphost) is set to Disabled" {
+        CISService "5.31 - (L1) Ensure UPnP Device Host (upnphost) is set to Disabled" {
             Name = 'upnphost'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.32' -and $LevelOne){
-        Service "5.32 - (L1) Ensure Web Management Service (WMSvc) is set to Disabled or Not Installed" {
+        CISService "5.32 - (L1) Ensure Web Management Service (WMSvc) is set to Disabled or Not Installed" {
             Name = 'WMSVC'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.33' -and $LevelTwo){
-        Service "5.33 - (L2) Ensure Windows Error Reporting Service (WerSvc) is set to Disabled" {
+        CISService "5.33 - (L2) Ensure Windows Error Reporting Service (WerSvc) is set to Disabled" {
             Name = 'WerSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.34' -and $LevelTwo){
-        Service "5.34 - (L2) Ensure Windows Event Collector (Wecsvc) is set to Disabled" {
+        CISService "5.34 - (L2) Ensure Windows Event Collector (Wecsvc) is set to Disabled" {
             Name = 'Wecsvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.35' -and $LevelOne){
-        Service "5.35 - (L1) Ensure Windows Media Player Network Sharing Service (WMPNetworkSvc) is set to Disabled or Not Installed" {
+        CISService "5.35 - (L1) Ensure Windows Media Player Network Sharing Service (WMPNetworkSvc) is set to Disabled or Not Installed" {
             Name = 'WMPNetworkSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.36' -and $LevelOne){
-        Service "5.36 - (L1) Ensure Windows Mobile Hotspot Service (icssvc) is set to Disabled" {
+        CISService "5.36 - (L1) Ensure Windows Mobile Hotspot Service (icssvc) is set to Disabled" {
             Name = 'icssvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.37' -and $LevelTwo){
-        Service "5.37 - (L2) Ensure Windows Push Notifications System Service (WpnService) is set to Disabled" {
+        CISService "5.37 - (L2) Ensure Windows Push Notifications System Service (WpnService) is set to Disabled" {
             Name = 'WpnService'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.38' -and $LevelTwo){
-        Service "5.38 - (L2) Ensure Windows PushToInstall Service (PushToInstall) is set to Disabled" {
+        CISService "5.38 - (L2) Ensure Windows PushToInstall Service (PushToInstall) is set to Disabled" {
             Name = 'PushToInstall'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.39' -and $LevelTwo){
-        Service "5.39 - (L2) Ensure Windows Remote Management (WS-Management) (WinRM) is set to Disabled" {
+        CISService "5.39 - (L2) Ensure Windows Remote Management (WS-Management) (WinRM) is set to Disabled" {
             Name = 'WinRM'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.40' -and $LevelOne){
-        Service "5.40 - (L1) Ensure World Wide Web Publishing Service (W3SVC) is set to Disabled or Not Installed" {
+        CISService "5.40 - (L1) Ensure World Wide Web Publishing Service (W3SVC) is set to Disabled or Not Installed" {
             Name = 'W3SVC'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.41' -and $LevelOne){
-        Service "5.41 - (L1) Ensure Xbox Accessory Management Service (XboxGipSvc) is set to Disabled" {
+        CISService "5.41 - (L1) Ensure Xbox Accessory Management Service (XboxGipSvc) is set to Disabled" {
             Name = 'XboxGipSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.42' -and $LevelOne){
-        Service "5.42 - (L1) Ensure Xbox Live Auth Manager (XblAuthManager) is set to Disabled" {
+        CISService "5.42 - (L1) Ensure Xbox Live Auth Manager (XblAuthManager) is set to Disabled" {
             Name = 'XblAuthManager'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.43' -and $LevelOne){
-        Service "5.43 - (L1) Ensure Xbox Live Game Save (XblGameSave) is set to Disabled" {
+        CISService "5.43 - (L1) Ensure Xbox Live Game Save (XblGameSave) is set to Disabled" {
             Name = 'XblGameSave'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '5.44' -and $LevelOne){
-        Service "5.44 - (L1) Ensure Xbox Live Networking Service (XboxNetApiSvc) is set to Disabled" {
+        CISService "5.44 - (L1) Ensure Xbox Live Networking Service (XboxNetApiSvc) is set to Disabled" {
             Name = 'XboxNetApiSvc'
-            State = 'Stopped'
         }
     }
     if($ExcludeList -notcontains '9.1.1' -and $LevelOne){

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -66,7 +66,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
-    Import-DSCResource -Name 'CISService'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 


### PR DESCRIPTION
- Corrected small typo in CISService comments

- Updated existing resources and examples for the CISService changes

- Continued work for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/121

- ScriptAnalyzer action was adjusted to look at the entire CISDSC module. The rule 'PSDSCDscTestsPresent' was excluded since this doesn't appear to like where the test folder is located at. There are indeed tests for this resource in the tests directory of this repo. It also now copies to the modules dir to satisfy some weird DSC behavior with detecting installed modules