### PR TITLE
Cis service generation

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 2.1.1
+### Added
+### Changed
+- Changed service logic to use the CISService resource
+### Removed
+
 ## 2.1 - 9/30/20
 ### Added
 - Functionality to generate resource documentation along side the DSC resources

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSCResourceGeneration.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.1.0'
+ModuleVersion = '2.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSCResourceGeneration/functions/private/ConvertFrom-ServiceRawGPO.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/ConvertFrom-ServiceRawGPO.ps1
@@ -2,10 +2,7 @@ function ConvertFrom-ServiceRawGPO {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string]$Service,
-
-        [Parameter(Mandatory = $true)]
-        [string]$ServiceData
+        [string]$Service
     )
 
     begin {
@@ -15,14 +12,7 @@ function ConvertFrom-ServiceRawGPO {
     process {
         $serviceHash = @{
             'Name' = $Service
-            'ResourceType' = 'Service'
-        }
-
-        switch (($ServiceData -split ',')[0]){
-            '2' {$serviceHash.Add('State',"'Running'")}
-            '3' {$serviceHash.Add('StartupType',"'Manual'")}
-            '4' {$serviceHash.Add('State',"'Stopped'")}
-            Default {Write-Warning -Message "Invalid ServiceData of $($values[0])) for $($Service)"}
+            'ResourceType' = 'CISService'
         }
 
         $RecommendationNum = Get-RecommendationFromGPOHash -GPOHash $serviceHash -Type 'Service'

--- a/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
@@ -36,7 +36,7 @@ function Import-GptTmpl {
                         'Registry Values' {ConvertFrom-RegistryValueRawGPO -Key $subkey -ValueData $ini[$key][$subKey]}
                         'Privilege Rights' {ConvertFrom-PrivilegeRightRawGPO -Policy $subkey -Identity $ini[$key][$subKey]}
                         'System Access' {ConvertFrom-SystemAccessRawGPO -Key $subkey -SecurityData $ini[$key][$subKey]}
-                        'Service General Setting' {ConvertFrom-ServiceRawGPO -Service $subkey -ServiceData $ini[$key][$subKey]}
+                        'Service General Setting' {ConvertFrom-ServiceRawGPO -Service $subkey}
                         Default {Write-Warning -Message "Inf: $($Key) not yet supported."}
                     }
                 }

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.schema.psm1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.schema.psm1.plaster
@@ -6,6 +6,7 @@ Configuration CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CISService'
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -205,7 +205,7 @@ Describe 'Helper: Conversion functions' {
         It 'ConvertFrom-ServiceRawGPO returns valid objects' {
             ConvertFrom-ServiceRawGPO -Service 'IISADMIN'
             ($script:BenchmarkRecommendations['5.6'].ResourceParameters | Measure-Object).Count | Should -Not -Be 0
-            $script:BenchmarkRecommendations['5.6'].ResourceParameters[0].keys | Where-Object -FilterScript {$_ -notin ('Name')} | Should -Be $null
+            $script:BenchmarkRecommendations['5.6'].ResourceParameters[0].keys | Where-Object -FilterScript {$_ -notin ('Name','ResourceType')} | Should -Be $null
         }
 
         It 'ConvertFrom-SystemAccessRawGPO returns valid objects' {

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -203,9 +203,9 @@ Describe 'Helper: Conversion functions' {
         }
 
         It 'ConvertFrom-ServiceRawGPO returns valid objects' {
-            ConvertFrom-ServiceRawGPO -Service 'IISADMIN' -ServiceData '4'
+            ConvertFrom-ServiceRawGPO -Service 'IISADMIN'
             ($script:BenchmarkRecommendations['5.6'].ResourceParameters | Measure-Object).Count | Should -Not -Be 0
-            $script:BenchmarkRecommendations['5.6'].ResourceParameters[0].keys | Where-Object -FilterScript {$_ -notin ('Name','State','ResourceType')} | Should -Be $null
+            $script:BenchmarkRecommendations['5.6'].ResourceParameters[0].keys | Where-Object -FilterScript {$_ -notin ('Name')} | Should -Be $null
         }
 
         It 'ConvertFrom-SystemAccessRawGPO returns valid objects' {


### PR DESCRIPTION
- service resource related functions where adapted to use the new resource. Service data was removed from ConvertFrom-ServiceRawGPO as this was an artifact of forking the baseline management module. CIS only recommends disabling services so we don't need to worry about translating the value. These were being inaccurately translated anyways.

- pester tests where updated to reflect new expectations of the functions

- part 3 for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/121