### PR TITLE
v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CISService resource. This is a custom resource for managing services that will consider an absent or disabled service to be in desired state.
 ### Changed
 - Updated Windows 10 Enterprise 1809, 1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors. This is not a breaking a change.
+### Removed
+- Removed duplicate entry for HKLM:\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoGPOListChanges
 
 ## [1.0.2] - 2020-09-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added CISService resource. This is a custom resource for managing services that will consider an absent or disabled service to be in desired state.
 ### Changed
-- Updated Windows 10 Enterprise 1809, 1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors.
+- Updated Windows 10 Enterprise 1809, 1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors. This is not a breaking a change.
 
 ## [1.0.2] - 2020-09-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added CISService resource. This is a custom resource for managing services that will consider an absent or disabled service to be in desired state.
 ### Changed
-- Updated Windows 10 Enterprise 1809,1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors.
+- Updated Windows 10 Enterprise 1809, 1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors.
 
 ## [1.0.2] - 2020-09-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated Windows 10 Enterprise 1809, 1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors. This is not a breaking a change.
 ### Removed
-- Removed duplicate entry for HKLM:\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoGPOListChanges
+- Removed duplicate entry for HKLM:\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoGPOListChanges in Windows 10 Enterprise 1809
 
 ## [1.0.2] - 2020-09-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added CISService resource. This is a custom resource for managing services that will pass absent or disabled removing the need to add absent services to the ExcludeList of configurations.
-- Updated Windows 10 Enterprise 1809,1909, and 2004 to use the new CISService resource.
-
 ### Changed
 ### Removed
+
+## [1.1.0] - 2020-10-05
+### Added
+- Added CISService resource. This is a custom resource for managing services that will consider an absent or disabled service to be in desired state.
+### Changed
+- Updated Windows 10 Enterprise 1809,1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors.
 
 ## [1.0.2] - 2020-09-30
 ### Added

--- a/src/CISDSC/CISDSC.psd1
+++ b/src/CISDSC/CISDSC.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSC.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.6.1.2'
+ModuleVersion = '1.6.1.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
@@ -2360,18 +2360,11 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         }
     }
     if($ExcludeList -notcontains '18.8.21.2' -and $LevelOne){
-        Registry "18.8.21.2 - (L1) Ensure Configure registry policy processing Do not apply during periodic background processing is set to Enabled FALSE (1)" {
+        Registry "18.8.21.2 - (L1) Ensure Configure registry policy processing Do not apply during periodic background processing is set to Enabled FALSE" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}'
             ValueData = 0
             ValueName = 'NoBackgroundPolicy'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.21.2 - (L1) Ensure Configure registry policy processing Do not apply during periodic background processing is set to Enabled FALSE (2)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}'
-            ValueData = 0
-            ValueName = 'NoGPOListChanges'
             ValueType = 'Dword'
         }
     }

--- a/static_corrections/Win10_1809_corrections.csv
+++ b/static_corrections/Win10_1809_corrections.csv
@@ -16,7 +16,7 @@
 "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE:UseTPMKeyPIN","18.9.11.2.16","These are unmentioned keys impacted by the remediation steps"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MicrosoftEdge\Security:FlashClickToRunMode","18.9.45.9","Outdate key in benchmark, https://getadmx.com/?Category=Windows_10_2016&Policy=Microsoft.Policies.MicrosoftEdge::AllowFlashClickToRun"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoBackgroundPolicy","18.8.21.2","Benchmark has a typo. '\NoBackgroundPolicy' vs ':NoBackgroundPolicy'"
-"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoGPOListChanges","18.8.21.2","Benchmark has a typo. '\NoGPOListChanges' vs ':NoGPOListChanges'"
+"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoGPOListChanges","18.8.21.3","Benchmark has a typo. '\NoGPOListChanges' vs ':NoGPOListChanges'"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\HomeGroup:DisableHomeGroup","18.9.35.1","Benchmark has a typo. '\DisableHomeGroup' vs ':DisableHomeGroup'"
 "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging:EnableScriptBlockInvocationLogging","18.9.95.1","Outdated key in benchmark, https://getadmx.com/?Category=Windows_10_2016&Policy=Microsoft.Policies.PowerShell::EnableScriptBlockLogging"
 "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters:DisabledComponents","18.5.19.2.1","Benchmark has a typo. 'Parameters' vs 'Parameter'"


### PR DESCRIPTION
- Bumped manifest version

- Finalized changelog wording

- Deemed worthy of a minor release bump since this adds new functionality

- Removed duplicate key from Win10 1809 this somehow ended up in two recommendations when generated. Didn't appear present in later builds.