### PR TITLE
Added bundled resource examples to the Plaster template and bugfix

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -9,23 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 2.2.1
+### Added
+- Added resource example files to the Plaster template [Issue 133](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133)
+
 ## 2.2.0
 ### Added
-- Added support for overriding parameters that are generated
+- Added support for overriding parameters that are generated [Issue 71](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/71)
 
 ## 2.1.2
 ### Added
-- Added support for dynamic setting on recommendation IDs on the special case recommendations (legal notice and account renames)
+- Added support for dynamic setting on recommendation IDs on the special case recommendations (legal notice and account renames) [Issue 129](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/129)
 
 ## 2.1.1
 ### Added
 ### Changed
-- Changed service logic to use the CISService resource
+- Changed service logic to use the CISService resource [Issue 121](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/121)
 ### Removed
 
 ## 2.1 - 9/30/20
 ### Added
-- Functionality to generate resource documentation along side the DSC resources
+- Functionality to generate resource documentation along side the DSC resources [Issue 114](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/114)
 
 ## [2.0.0]
 - Start of changelog

--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.2.1
 ### Added
 - Added resource example files to the Plaster template [Issue 133](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133)
+### Changed
+- Corrected special case for HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\ScreenSaverGracePeriod incorrectly setting to DWORD instead of string [Issue 136](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/136)
 
 ## 2.2.0
 ### Added

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSCResourceGeneration.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.0'
+ModuleVersion = '2.2.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSCResourceGeneration/functions/private/Resolve-RegistryValueSpecialCases.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Resolve-RegistryValueSpecialCases.ps1
@@ -26,9 +26,10 @@ Function Resolve-RegistryValueSpecialCases
         }
 
         'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\ScreenSaverGracePeriod'{
-            #This comes through as a string for some reason but should be a DWORD per https://getadmx.com/?Category=SecurityBaseline&Policy=Microsoft.Policies.MSS::Pol_MSS_ScreenSaverGracePeriod
-            $regHash.ValueData = 0
-            $regHash.ValueType = 'Dword'
+            #There is conflicting documentation on this keys value type but more sources say string and that's what CIS-CAT looks for as well.
+            #The buildkit sets this to 5 but the title recommends 0 so the value is overridden.
+            $regHash.ValueData = '0'
+            $regHash.ValueType = 'String'
         }
 
         'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeText'{

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
@@ -14,10 +14,10 @@ Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
     {
         CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
         {
-            '2315AccountsRenameadministratoraccount' = 'CISAdmin'
-            '2316AccountsRenameguestaccount' = 'CISGuest'
-            '2376LegalNoticeCaption' = 'Legal Notice'
-            '2375LegalNoticeText' = @"
+            '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
+            '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
+            '<%=$PLASTER_PARAM_LegalNoticeCaptionNumNoDots%>LegalNoticeCaption' = 'Legal Notice'
+            '<%=$PLASTER_PARAM_LegalNoticeTextNumNoDots%>LegalNoticeText' = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
@@ -1,0 +1,30 @@
+#Requires -module CISDSC
+
+<#
+    .DESCRIPTION
+    Applies CIS Level one benchmarks for <%=$PLASTER_PARAM_OS%> build <%=$PLASTER_PARAM_OSBuild%> the no exclusions.
+    Exclusion documentation can be found in the docs folder of this module.
+#>
+
+Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
+{
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+
+    node 'localhost'
+    {
+        CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
+        {
+            '2315AccountsRenameadministratoraccount' = 'CISAdmin'
+            '2316AccountsRenameguestaccount' = 'CISGuest'
+            '2376LegalNoticeCaption' = 'Legal Notice'
+            '2375LegalNoticeText' = @"
+This is a super secure device that we don't want bad people using.
+I'm even making sure to put this as a literal string so that I can cleanly
+use multiple lines to tell you how super secure it is.
+"@
+        }
+    }
+}
+
+<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
+Start-DscConfiguration -Path '.\<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1' -Verbose -Wait

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
@@ -22,10 +22,10 @@ Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAP
 
         CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
         {
-            '2315AccountsRenameadministratoraccount' = 'CISAdmin'
-            '2316AccountsRenameguestaccount' = 'CISGuest'
-            '2376LegalNoticeCaption' = 'Legal Notice'
-            '2375LegalNoticeText' = @"
+            '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
+            '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
+            '<%=$PLASTER_PARAM_LegalNoticeCaptionNumNoDots%>LegalNoticeCaption' = 'Legal Notice'
+            '<%=$PLASTER_PARAM_LegalNoticeTextNumNoDots%>LegalNoticeText' = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
@@ -1,0 +1,39 @@
+#Requires -module CISDSC
+
+<#
+    .DESCRIPTION
+    Applies CIS Level one benchmarks for <%=$PLASTER_PARAM_OS%> build <%=$PLASTER_PARAM_OSBuild%> the no exclusions.
+    Exclusion documentation can be found in the docs folder of this module.
+    This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
+#>
+
+Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS
+{
+    Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+
+    node 'localhost'
+    {
+        Package 'InstallLAPS' {
+            Name  = 'Local Administrator Password Solution'
+            Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
+            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+        }
+
+        CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
+        {
+            '2315AccountsRenameadministratoraccount' = 'CISAdmin'
+            '2316AccountsRenameguestaccount' = 'CISGuest'
+            '2376LegalNoticeCaption' = 'Legal Notice'
+            '2375LegalNoticeText' = @"
+This is a super secure device that we don't want bad people using.
+I'm even making sure to put this as a literal string so that I can cleanly
+use multiple lines to tell you how super secure it is.
+"@
+            'DependsOn' = '[Package]InstallLAPS'
+        }
+    }
+}
+
+<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS
+Start-DscConfiguration -Path '.\<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS' -Verbose -Wait

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/plasterManifest.xml
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/plasterManifest.xml
@@ -88,6 +88,13 @@
 
         <templateFile source='resource.documentation.md'
                       destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}.md'/>
+
+        <templateFile source='example.ps1.plaster'
+                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}.ps1'/>
+
+        <templateFile source='example_With_LAPS.ps1.plaster'
+                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}_With_LAPS.ps1'/>
+
         <message>
 
 Your new PowerShell DSC resource has been created.

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -337,9 +337,14 @@ Describe 'ConvertTo-DSC' {
         }
         ConvertTo-DSC @Splat
 
-        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1' | Should -Be $True
-        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1' | Should -Be $True
-        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.md' | Should -Be $True
+        [string[]]$Paths = (
+            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1',
+            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1',
+            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.md',
+            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1',
+            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1'
+        )
+        Test-Path -Path $Paths | Select-Object -Unique | Should -Be $True
     }
 
     #ToDo find a way to actually test the composite resource can be used in a configuration successfully.


### PR DESCRIPTION
- Solution for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133

- Solution for https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/136

- The example files packaged with the module were being created by hand due to needing custom exclusion lists previously. This is no longer the case so they have been added as file templates to Plaster.