### PR TITLE
Optimized pester actions

### DIFF
--- a/.github/workflows/pester_CISDSC.yml
+++ b/.github/workflows/pester_CISDSC.yml
@@ -1,0 +1,25 @@
+name: CISDSC Pester Tests
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - 'src/CISDSC/CISDSC.psm1'
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: Install-Module -Name 'PSDepend' -Force -SkipPublisherCheck; Invoke-PSDepend -Force
+      shell: powershell
+    - name: Run tests PowerShell 5
+      run: Invoke-Pester -Path '.\test\CISDSC.Tests.ps1' -CI -Output Detailed
+      shell: powershell

--- a/.github/workflows/pester_CISDSCResourceGeneration.yml
+++ b/.github/workflows/pester_CISDSCResourceGeneration.yml
@@ -1,11 +1,11 @@
-name: Pester Tests
+name: CISDSCResourceGeneration Pester Tests
 
 on:
   pull_request:
     branches:
     - main
     paths:
-    - 'src/**'
+    - 'src/CISDSCResourceGeneration/**'
 
 jobs:
   build:
@@ -21,5 +21,5 @@ jobs:
       run: Install-Module -Name 'PSDepend' -Force -SkipPublisherCheck; Invoke-PSDepend -Force
       shell: powershell
     - name: Run tests PowerShell 5
-      run: Invoke-Pester -Path '.\test\' -CI -Output Detailed
+      run: Invoke-Pester -Path '.\test\CISDSCResourceGeneration.Tests.ps1' -CI -Output Detailed
       shell: powershell

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Pester Tests](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/workflows/Pester%20Tests/badge.svg)
+![CISDSC Pester Tests](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/workflows/CISDSCResourceGeneration%20Pester%20Tests/badge.svg)
+![CISDSCResourceGeneration Pester Tests](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/workflows/CISDSC%20Pester%20Tests/badge.svg)
 ![ScriptAnalyzer](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/workflows/ScriptAnalyzer/badge.svg)
 
 # What is This?


### PR DESCRIPTION
- Split unit test actions up for the two modules. This way tests will only run when relevant files are changed.

- CISDSC tests are scoped explicitly to the PSM1 file since this is the only file with non-generated code in it and the others change often.

- Updated badges in the README