### PR TITLE
Standardized casing

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.2.2
 ### Changed
 - Standardized casing for typing on resource parameters [Issue 143](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/143)
-
+- Corrected plaster template for resource documentation to use the dynamic recommendation IDs from [Issue 129](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/129)
 ## 2.2.1
 ### Added
 - Added resource example files to the Plaster template [Issue 133](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133)

--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Standardized casing for typing on resource parameters [Issue 143](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/143)
 - Corrected plaster template for resource documentation to use the dynamic recommendation IDs from [Issue 129](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/129)
+
 ## 2.2.1
 ### Added
 - Added resource example files to the Plaster template [Issue 133](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133)

--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 2.2.2
+### Changed
+- Standardized casing for typing on resource parameters [Issue 143](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/143)
+
 ## 2.2.1
 ### Added
 - Added resource example files to the Plaster template [Issue 133](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133)

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSCResourceGeneration.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.1'
+ModuleVersion = '2.2.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
@@ -181,9 +181,9 @@ Class Recommendation{
                         switch($Hash['ResourceType']){
                             'Registry'{
                                 [string]$DataType = switch($Hash['ValueType']){
-                                    "'String'" {'[string]'}
-                                    "'MultiString'" {'[string[]]'}
-                                    "'Dword'" {'[int32]'}
+                                    "'String'" {'[String]'}
+                                    "'MultiString'" {'[String[]]'}
+                                    "'Dword'" {'[Int32]'}
                                 }
                                 $This.DSCConfigParameter = [DSCConfigurationParameter]::new($This.RecommendationNum,$Hash['ValueName'],$DataType,$Hash['ValueData'])
                                 $Hash['ValueData'] = $This.DSCConfigParameter.Name

--- a/src/CISDSCResourceGeneration/functions/private/Get-DSCParameterTextBlocks.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Get-DSCParameterTextBlocks.ps1
@@ -11,19 +11,19 @@ function Get-DSCParameterTextBlocks {
 
     process {
         [System.Collections.ArrayList]$DSCConfigurationParameters = @()
-        $DSCConfigurationParameters += '        [string[]]$ExcludeList = @()'
+        $DSCConfigurationParameters += '        [String[]]$ExcludeList = @()'
 
         if($Levels -contains 'LevelOne'){
-            $DSCConfigurationParameters += '        [boolean]$LevelOne = $true'
+            $DSCConfigurationParameters += '        [Boolean]$LevelOne = $true'
         }
         if($Levels -contains 'LevelTwo'){
-            $DSCConfigurationParameters += '        [boolean]$LevelTwo = $false'
+            $DSCConfigurationParameters += '        [Boolean]$LevelTwo = $false'
         }
         if($Levels -contains 'BitLocker'){
-            $DSCConfigurationParameters += '        [boolean]$BitLocker = $false'
+            $DSCConfigurationParameters += '        [Boolean]$BitLocker = $false'
         }
         if($Levels -contains 'NextGenerationWindowsSecurity'){
-            $DSCConfigurationParameters += '        [boolean]$NextGenerationWindowsSecurity = $false'
+            $DSCConfigurationParameters += '        [Boolean]$NextGenerationWindowsSecurity = $false'
         }
 
         $DSCConfigurationParameters += (($Recommendations).DSCConfigParameter | Sort-Object -Property 'Name').TextBlock

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.documentation.md
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.documentation.md
@@ -13,10 +13,10 @@ mechanism to apply CIS benchmarks on a target node running <%=$PLASTER_PARAM_OS%
 ## Syntax
 
 ```Syntax
-CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> [string] #ResourceName
+CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> [String] #ResourceName
 {
 <%=$PLASTER_PARAM_DocumentationSyntax%>
-    [ DependsOn = [string[]] ]
+    [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.documentation.md
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.documentation.md
@@ -25,10 +25,10 @@ CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> [String] #Resourc
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExclusionList. This is because these values will always be organization specific so a default value is not appropriate.
-> `2315AccountsRenameadministratoraccount`,
-> `2316AccountsRenameguestaccount`,
-> `2376LegalNoticeCaption`,
-> `2375LegalNoticeText`
+> `<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount`,
+> `<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount`,
+> `<%=$PLASTER_PARAM_LegalNoticeCaptionNumNoDots%>LegalNoticeCaption`,
+> `<%=$PLASTER_PARAM_LegalNoticeTextNumNoDots%>LegalNoticeText`
 ## Properties
 
 |Property |DefaultValue | Recommendation ID|Recommendation
@@ -57,10 +57,10 @@ Configuration MyConfiguration
 
     CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
     {
-        '2315AccountsRenameadministratoraccount' = 'CISAdmin'
-        '2316AccountsRenameguestaccount' = 'CISGuest'
-        '2376LegalNoticeCaption' = 'Legal Notice'
-        '2375LegalNoticeText' = @"
+        '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
+        '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
+        '<%=$PLASTER_PARAM_LegalNoticeCaptionNumNoDots%>LegalNoticeCaption' = 'Legal Notice'
+        '<%=$PLASTER_PARAM_LegalNoticeTextNumNoDots%>LegalNoticeText' = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.
@@ -79,12 +79,12 @@ Configuration MyConfiguration
     CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
     {
         'ExcludeList' = @(
-            '2.3.7.5', # LegalNoticeText
-            '2.3.7.6', # LegalNoticeCaption
+            '<%=$PLASTER_PARAM_LegalNoticeTextNum%>', # LegalNoticeText
+            '<%=$PLASTER_PARAM_LegalNoticeCaptionNum%>', # LegalNoticeCaption
             '5.6' # IIS Admin Service (IISADMIN)
         )
-        '2315AccountsRenameadministratoraccount' = 'CISAdmin'
-        '2316AccountsRenameguestaccount' = 'CISGuest'
+        '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
+        '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
     }
 }
 ```
@@ -107,12 +107,12 @@ Configuration MyConfiguration
         CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
         {
             'ExcludeList' = @(
-                '2.3.7.5', # LegalNoticeText
-                '2.3.7.6', # LegalNoticeCaption
+                '<%=$PLASTER_PARAM_LegalNoticeTextNum%>', # LegalNoticeText
+                '<%=$PLASTER_PARAM_LegalNoticeCaptionNum%>', # LegalNoticeCaption
                 '5.6' # IIS Admin Service (IISADMIN)
             )
-            '2315AccountsRenameadministratoraccount' = 'CISAdmin'
-            '2316AccountsRenameguestaccount' = 'CISGuest'
+            '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
+            '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
             'DependsOn' = '[Package]InstallLAPS'
         }
     }


### PR DESCRIPTION
- Solution for #143 

- The dynamically generated types where camel cased while the statically typed ones were all lower case. I updated the static ones to be camel as well.

- Corrected plaster template for resource documentation to use the dynamic recommendation IDs from [Issue 129](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/129)