### PR TITLE
Added RunAsAdministrator requirement to packaged examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Added RunAsAdministrator requirement to packaged examples
 ### Changed
 ### Removed
 

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
@@ -1,4 +1,5 @@
 #Requires -module CISDSC
+#Requires -RunAsAdministrator
 
 <#
     .DESCRIPTION


### PR DESCRIPTION
- All the examples require admin rights to work so I added the requirements flag to the scripts.

- Plaster templates were updated so this would be reflected on future examples.