### PR TITLE
#159 Generation

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 2.2.4
+### Changed
+- Updated the Plaster template to take the OS name with and without underscores. [Issue 159](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/159)
+
 ## 2.2.3
 ### Changed
 - Fixed a few missed casing fixes for [Issue 143](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/143)

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSCResourceGeneration.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.3'
+ModuleVersion = '2.2.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSCResourceGeneration/functions/public/ConvertTo-DSC.ps1
+++ b/src/CISDSCResourceGeneration/functions/public/ConvertTo-DSC.ps1
@@ -122,7 +122,8 @@ function ConvertTo-DSC {
                 'TemplatePath' = (Join-Path -Path $script:PlasterTemplatePath -ChildPath 'NewBenchmarkCompositeResource')
                 'DestinationPath' = $ResourcePath
                 'NoLogo' = $true
-                'OS' = $OS.replace(' ','_')
+                'OS' = $OS
+                'OSWithUnderscores' = $OS.replace(' ','_')
                 'OSBuild' = $OSBuild
                 'BenchmarkVersion' = $BenchmarkVersion.ToString()
                 'DSCParameters' = ($DSCConfigurationParameters -join ",`n")

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example.ps1.plaster
@@ -7,13 +7,13 @@
     Exclusion documentation can be found in the docs folder of this module.
 #>
 
-Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
+Configuration <%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
 {
-    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
 
     node 'localhost'
     {
-        CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
+        CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
         {
             '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
             '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
@@ -27,5 +27,5 @@ use multiple lines to tell you how super secure it is.
     }
 }
 
-<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
-Start-DscConfiguration -Path '.\<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1' -Verbose -Wait
+<%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1
+Start-DscConfiguration -Path '.\<%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1' -Verbose -Wait

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
@@ -8,10 +8,10 @@
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>
 
-Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS
+Configuration <%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS
 {
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
-    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
 
     node 'localhost'
     {
@@ -22,7 +22,7 @@ Configuration <%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAP
             ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
         }
 
-        CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
+        CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'
         {
             '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
             '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
@@ -37,5 +37,5 @@ use multiple lines to tell you how super secure it is.
     }
 }
 
-<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS
-Start-DscConfiguration -Path '.\<%=$PLASTER_PARAM_OS%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS' -Verbose -Wait
+<%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS
+Start-DscConfiguration -Path '.\<%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_CIS_L1_with_LAPS' -Verbose -Wait

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/manifest.psd1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/manifest.psd1.plaster
@@ -1,7 +1,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-RootModule = 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>.schema.psm1'
+RootModule = 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>.schema.psm1'
 
 # Version number of this module.
 ModuleVersion = '<%=$PLASTER_PARAM_BenchmarkVersion%>'
@@ -61,7 +61,7 @@ Description = 'Applies CIS benchmarks for <%=$PLASTER_PARAM_OS%> release <%=$PLA
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+FunctionsToExport = 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 # CmdletsToExport = '*'

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/plasterManifest.xml
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/plasterManifest.xml
@@ -83,19 +83,19 @@
         <message>&#10;&#10;Scaffolding your DSC resource...&#10;&#10;&#10;</message>
 
         <templateFile source='manifest.psd1.plaster'
-                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}.psd1'/>
+                      destination='CIS_${PLASTER_PARAM_OSWithUnderscores}_Release_${PLASTER_PARAM_OSBuild}.psd1'/>
 
         <templateFile source='resource.schema.psm1.plaster'
-                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}.schema.psm1'/>
+                      destination='CIS_${PLASTER_PARAM_OSWithUnderscores}_Release_${PLASTER_PARAM_OSBuild}.schema.psm1'/>
 
         <templateFile source='resource.documentation.md'
-                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}.md'/>
+                      destination='CIS_${PLASTER_PARAM_OSWithUnderscores}_Release_${PLASTER_PARAM_OSBuild}.md'/>
 
         <templateFile source='example.ps1.plaster'
-                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}.ps1'/>
+                      destination='CIS_${PLASTER_PARAM_OSWithUnderscores}_Release_${PLASTER_PARAM_OSBuild}.ps1'/>
 
         <templateFile source='example_With_LAPS.ps1.plaster'
-                      destination='CIS_${PLASTER_PARAM_OS}_Release_${PLASTER_PARAM_OSBuild}_With_LAPS.ps1'/>
+                      destination='CIS_${PLASTER_PARAM_OSWithUnderscores}_Release_${PLASTER_PARAM_OSBuild}_With_LAPS.ps1'/>
 
         <message>
 

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/plasterManifest.xml
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/plasterManifest.xml
@@ -14,9 +14,11 @@
   <parameters>
         <parameter name='OS'
                    type='text'
-                   prompt='Select OS'>
+                   prompt='Select OS'/>
 
-        </parameter>
+        <parameter name='OSWithUnderscores'
+                   type='text'
+                   prompt='Select OS'/>
 
         <parameter name='BenchmarkVersion'
                    type='text'

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.documentation.md
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.documentation.md
@@ -1,19 +1,19 @@
 ---
 date: <%=$PLASTER_Date%>
 keywords: dsc,powershell,configuration,setup,cis,security,<%=$PLASTER_PARAM_OSBuild%>
-title: CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>
+title: CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>
 ---
-# DSC CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> Resource
+# DSC CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
 
-The **CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+The **CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>** resource in Windows PowerShell Desired State Configuration (DSC) provides a
 mechanism to apply CIS benchmarks on a target node running <%=$PLASTER_PARAM_OS%> release <%=$PLASTER_PARAM_OSBuild%>.
 
 ## Syntax
 
 ```Syntax
-CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> [String] #ResourceName
+CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> [String] #ResourceName
 {
 <%=$PLASTER_PARAM_DocumentationSyntax%>
     [ DependsOn = [String[]] ]
@@ -53,9 +53,9 @@ CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> [String] #Resourc
 ```powershell
 Configuration MyConfiguration
 {
-    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
 
-    CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
+    CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
     {
         '<%=$PLASTER_PARAM_AccountsRenameadministratoraccountNumNoDots%>AccountsRenameadministratoraccount' = 'CISAdmin'
         '<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount' = 'CISGuest'
@@ -74,9 +74,9 @@ use multiple lines to tell you how super secure it is.
 ```powershell
 Configuration MyConfiguration
 {
-    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
 
-    CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
+    CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
     {
         'ExcludeList' = @(
             '<%=$PLASTER_PARAM_LegalNoticeTextNum%>', # LegalNoticeText
@@ -94,7 +94,7 @@ Configuration MyConfiguration
 Configuration MyConfiguration
 {
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
-    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
+    Import-DSCResource -ModuleName 'CISDSC' -Name 'CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>'
 
     node 'localhost'
     {
@@ -105,7 +105,7 @@ Configuration MyConfiguration
             ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
         }
 
-        CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
+        CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'
         {
             'ExcludeList' = @(
                 '<%=$PLASTER_PARAM_LegalNoticeTextNum%>', # LegalNoticeText

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.schema.psm1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewBenchmarkCompositeResource/resource.schema.psm1.plaster
@@ -1,4 +1,4 @@
-Configuration CIS_<%=$PLASTER_PARAM_OS%>_Release_<%=$PLASTER_PARAM_OSBuild%>
+Configuration CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>
 {
     param
     (

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -333,14 +333,11 @@ Describe 'ConvertTo-DSC' {
         }
         ConvertTo-DSC @Splat
 
-        [string[]]$Paths = (
-            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1',
-            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1',
-            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.md',
-            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1',
-            '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1'
-        )
-        Test-Path -Path $Paths | Select-Object -Unique | Should -Be $True
+        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.psd1' | Should -Be $True
+        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1' | Should -Be $True
+        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.md' | Should -Be $True
+        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1' | Should -Be $True
+        Test-Path -Path '.\Output\CIS_Microsoft_Windows_10_Enterprise_Release_1909\CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1' | Should -Be $True
     }
 
     #ToDo find a way to actually test the composite resource can be used in a configuration successfully.


### PR DESCRIPTION
- Solution for #159 

- Replaced existing references to the OS variable in plaster to OSWithUnderscores

- Updated pester test to say which file is missing vs just a file is missing on the ConvertTo-DSC test

- Corrected the applicable locations of the Plaster template to use the OS string without underscores

- A separate PR will retroactively apply this to existing examples and docs in #161

Before
![image](https://user-images.githubusercontent.com/28571284/97620155-23986480-19ef-11eb-9762-0d2cc7ae65d3.png)


After
![image](https://user-images.githubusercontent.com/28571284/97620114-167b7580-19ef-11eb-9be0-61b051ba763c.png)
