### PR TITLE
#159 Retroactive

### DIFF
--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
@@ -3,7 +3,7 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Microsoft_Windows_10_Enterprise build 2004 with no exclusions.
+    Applies CIS Level one benchmarks for Microsoft Windows 10 Enterprise build 2004 with no exclusions.
     Exclusion documentation can be found in the docs folder of this module.
 #>
 

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
@@ -3,7 +3,7 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Microsoft_Windows_10_Enterprise build 2004 with no exclusions.
+    Applies CIS Level one benchmarks for Microsoft Windows 10 Enterprise build 2004 with no exclusions.
     Exclusion documentation can be found in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
@@ -3,7 +3,7 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Microsoft_Windows_Server_2016_Member_Server build 1607 with no exclusions.
+    Applies CIS Level one benchmarks for Microsoft Windows Server 2016 Member Server build 1607 with no exclusions.
     Exclusion documentation can be found in the docs folder of this module.
 #>
 

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
@@ -3,7 +3,7 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Microsoft_Windows_Server_2016_Member_Server build 1607 with no exclusions.
+    Applies CIS Level one benchmarks for Microsoft Windows Server 2016 Member Server build 1607 with no exclusions.
     Exclusion documentation can be found in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
@@ -3,7 +3,7 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Microsoft_Windows_Server_2019_Member_Server build 1809 with no exclusions.
+    Applies CIS Level one benchmarks for Microsoft Windows Server 2019 Member Server build 1809 with no exclusions.
     Exclusion documentation can be found in the docs folder of this module.
 #>
 

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
@@ -3,7 +3,7 @@
 
 <#
     .DESCRIPTION
-    Applies CIS Level one benchmarks for Microsoft_Windows_Server_2019_Member_Server build 1809 with no exclusions.
+    Applies CIS Level one benchmarks for Microsoft Windows Server 2019 Member Server build 1809 with no exclusions.
     Exclusion documentation can be found in the docs folder of this module.
     This will also install LAPS (Local Administrator Password Solution) from the internet via download.microsoft.com unless the URL is changed to a network accesible path for your envrionment.
 #>

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
@@ -8,7 +8,7 @@ title: CIS_Microsoft_Windows_10_Enterprise_Release_1809
 > Applies To: Windows PowerShell 5.1 and higher
 
 The **CIS_Microsoft_Windows_10_Enterprise_Release_1809** resource in Windows PowerShell Desired State Configuration (DSC) provides a
-mechanism to apply CIS benchmarks on a target node running Microsoft_Windows_10_Enterprise release 1809.
+mechanism to apply CIS benchmarks on a target node running Microsoft Windows 10 Enterprise release 1809.
 
 ## Syntax
 

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
@@ -8,7 +8,7 @@ title: CIS_Microsoft_Windows_10_Enterprise_Release_1909
 > Applies To: Windows PowerShell 5.1 and higher
 
 The **CIS_Microsoft_Windows_10_Enterprise_Release_1909** resource in Windows PowerShell Desired State Configuration (DSC) provides a
-mechanism to apply CIS benchmarks on a target node running Microsoft_Windows_10_Enterprise release 1909.
+mechanism to apply CIS benchmarks on a target node running Microsoft Windows 10 Enterprise release 1909.
 
 ## Syntax
 

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
@@ -8,7 +8,7 @@ title: CIS_Microsoft_Windows_10_Enterprise_Release_2004
 > Applies To: Windows PowerShell 5.1 and higher
 
 The **CIS_Microsoft_Windows_10_Enterprise_Release_2004** resource in Windows PowerShell Desired State Configuration (DSC) provides a
-mechanism to apply CIS benchmarks on a target node running Microsoft_Windows_10_Enterprise release 2004.
+mechanism to apply CIS benchmarks on a target node running Microsoft Windows 10 Enterprise release 2004.
 
 ## Syntax
 

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
@@ -8,49 +8,49 @@ title: CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
 > Applies To: Windows PowerShell 5.1 and higher
 
 The **CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607** resource in Windows PowerShell Desired State Configuration (DSC) provides a
-mechanism to apply CIS benchmarks on a target node running Microsoft_Windows_Server_2016_Member_Server release 1607.
+mechanism to apply CIS benchmarks on a target node running Microsoft Windows Server 2016 Member Server release 1607.
 
 ## Syntax
 
 ```Syntax
-CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [string] #ResourceName
+CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceName
 {
-    [ ExclusionList = [string[]] ]
-    [ LevelOne = [boolean] ]
-    [ LevelTwo = [boolean] ]
-    [ NextGenerationWindowsSecurity = [boolean] ]
+    [ ExclusionList = [String[]] ]
+    [ LevelOne = [Boolean] ]
+    [ LevelTwo = [Boolean] ]
+    [ NextGenerationWindowsSecurity = [Boolean] ]
     [ 112MaximumPasswordAge = [Int32] { 60-999 } ]
     [ 113MinimumPasswordAge = [Int32] { 1-998 } ]
     [ 121Accountlockoutduration = [Int32] { 15-99999 } ]
     [ 122Accountlockoutthreshold = [Int32] { 10-999 } ]
     [ 123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
-    [ 1825PasswordLength = [int32] { 15-64 } ]
-    [ 1826PasswordAgeDays = [int32] { 30-365 } ]
-    [ 18412WarningLevel = [int32] { 0-90 } ]
-    [ 1849ScreenSaverGracePeriod = [string] { '0' | '1' | '2' | '3' | '4' | '5' } ]
-    [ 18910212DeferFeatureUpdatesPeriodInDays = [int32] { 180-365 } ]
-    [ 1892612MaxSize = [int32] { 32768-2147483647 } ]
-    [ 1892622MaxSize = [int32] { 196608-2147483647 } ]
-    [ 1892632MaxSize = [int32] { 32768-2147483647 } ]
-    [ 1892642MaxSize = [int32] { 32768-2147483647 } ]
-    [ 189593101MaxIdleTime = [int32] { 60000-900000 } ]
+    [ 1825PasswordLength = [Int32] { 15-64 } ]
+    [ 1826PasswordAgeDays = [Int32] { 30-365 } ]
+    [ 18412WarningLevel = [Int32] { 0-90 } ]
+    [ 1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
+    [ 18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
+    [ 1892612MaxSize = [Int32] { 32768-2147483647 } ]
+    [ 1892622MaxSize = [Int32] { 196608-2147483647 } ]
+    [ 1892632MaxSize = [Int32] { 32768-2147483647 } ]
+    [ 1892642MaxSize = [Int32] { 32768-2147483647 } ]
+    [ 189593101MaxIdleTime = [Int32] { 60000-900000 } ]
     [ 2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
     [ 2316AccountsRenameguestaccount = [String] { 1-256 } ]
-    [ 2365MaximumPasswordAge = [int32] { 1-30 } ]
-    [ 2373InactivityTimeoutSecs = [int32] { 1-900 } ]
-    [ 2374LegalNoticeText = [string] { 1-2048 } ]
-    [ 2375LegalNoticeCaption = [string] { 1-512 } ]
-    [ 2376CachedLogonsCount = [string] { '0' | '1' | '2' | '3' | '4' } ]
-    [ 2391AutoDisconnect = [int32] { 1-15 } ]
-    [ 916LogFileSize = [int32] { 16384-2147483647 } ]
-    [ 926LogFileSize = [int32] { 16384-2147483647 } ]
-    [ 938LogFileSize = [int32] { 16384-2147483647 } ]
-    [ DependsOn = [string[]] ]
+    [ 2365MaximumPasswordAge = [Int32] { 1-30 } ]
+    [ 2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
+    [ 2374LegalNoticeText = [String] { 1-2048 } ]
+    [ 2375LegalNoticeCaption = [String] { 1-512 } ]
+    [ 2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
+    [ 2391AutoDisconnect = [Int32] { 1-15 } ]
+    [ 916LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ 926LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ 938LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 > [!NOTE]
-> `[string]` parameters with a number range specifies valid lengths.
+> `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExclusionList. This is because these values will always be organization specific so a default value is not appropriate.

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
@@ -8,7 +8,7 @@ title: CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
 > Applies To: Windows PowerShell 5.1 and higher
 
 The **CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809** resource in Windows PowerShell Desired State Configuration (DSC) provides a
-mechanism to apply CIS benchmarks on a target node running Microsoft_Windows_Server_2019_Member_Server release 1809.
+mechanism to apply CIS benchmarks on a target node running Microsoft Windows Server 2019 Member Server release 1809.
 
 ## Syntax
 


### PR DESCRIPTION
- Retroactively applied fix for #159 that was added in #160 to remove underscores from various generated comments

- Fixed yet more inconsistent casing found in the Server 2016 documentation

