### PR TITLE
Issue169 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
-## [2.1.0] - 2021-01-25
+## [2.1.1] - 2021-01-26
 ### Added
 ### Changed
-- All parameter names with a lead numeric character (those associated with recommendations) have been prefixed with an "a". This is to allign with standard naming conventions for DSC resources and to resolve issues with platforms such as Azure Automation and AWX. THIS IS A BREAKING CHANGE FOR EXISTING CONFIGURATIONS.
+- All parameter names with a lead numeric character (those associated with recommendations) have been prefixed with an "cis". This is to allign with standard naming conventions for DSC resources and to resolve issues with platforms such as Azure Automation and AWX. THIS IS A BREAKING CHANGE FOR EXISTING CONFIGURATIONS.
 - Corrected references of 'ExclusionList' to 'ExcludeList'
 ### Removed
 

--- a/docs/auditing.md
+++ b/docs/auditing.md
@@ -27,8 +27,8 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1
     {
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             a2375LegalNoticeCaption = 'Legal Notice'
             a2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.

--- a/docs/auditing.md
+++ b/docs/auditing.md
@@ -29,8 +29,8 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1
         {
             cis2315AccountsRenameadministratoraccount = 'CISAdmin'
             cis2316AccountsRenameguestaccount = 'CISGuest'
-            a2375LegalNoticeCaption = 'Legal Notice'
-            a2374LegalNoticeText = @"
+            cis2375LegalNoticeCaption = 'Legal Notice'
+            cis2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/CISDSC.psd1
+++ b/src/CISDSC/CISDSC.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSC.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.1.0'
+ModuleVersion = '2.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809.ps1
@@ -15,10 +15,10 @@ Configuration Win10_1809_L1
     {
         CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
-            a2376LegalNoticeCaption = 'Legal Notice'
-            a2375LegalNoticeText = @"
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
+            cis2376LegalNoticeCaption = 'Legal Notice'
+            cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
@@ -22,10 +22,10 @@ Configuration Win10_1809_L1_With_LAPS
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CIS Benchmarks' {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
-            a2376LegalNoticeCaption = 'Legal Notice'
-            a2375LegalNoticeText = @"
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
+            cis2376LegalNoticeCaption = 'Legal Notice'
+            cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909.ps1
@@ -15,10 +15,10 @@ Configuration Win10_1909_L1
     {
         CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
-            a2376LegalNoticeCaption = 'Legal Notice'
-            a2375LegalNoticeText = @"
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
+            cis2376LegalNoticeCaption = 'Legal Notice'
+            cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
@@ -22,10 +22,10 @@ Configuration Win10_1909_L1_With_LAPS
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CIS Benchmarks' {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
-            a2376LegalNoticeCaption = 'Legal Notice'
-            a2375LegalNoticeText = @"
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
+            cis2376LegalNoticeCaption = 'Legal Notice'
+            cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004.ps1
@@ -15,10 +15,10 @@ Configuration Microsoft_Windows_10_Enterprise_2004_CIS_L1
     {
         CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
-            a2376LegalNoticeCaption = 'Legal Notice'
-            a2375LegalNoticeText = @"
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
+            cis2376LegalNoticeCaption = 'Legal Notice'
+            cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
@@ -24,10 +24,10 @@ Configuration Microsoft_Windows_10_Enterprise_2004_CIS_L1_with_LAPS
 
         CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
-            a2376LegalNoticeCaption = 'Legal Notice'
-            a2375LegalNoticeText = @"
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
+            cis2376LegalNoticeCaption = 'Legal Notice'
+            cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
@@ -17,8 +17,8 @@ Configuration Microsoft_Windows_Server_2016_Member_Server_1607_CIS_L1
         {
             cis2315AccountsRenameadministratoraccount = 'CISAdmin'
             cis2316AccountsRenameguestaccount = 'CISGuest'
-            a2375LegalNoticeCaption = 'Legal Notice'
-            a2374LegalNoticeText = @"
+            cis2375LegalNoticeCaption = 'Legal Notice'
+            cis2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.ps1
@@ -15,8 +15,8 @@ Configuration Microsoft_Windows_Server_2016_Member_Server_1607_CIS_L1
     {
         CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             a2375LegalNoticeCaption = 'Legal Notice'
             a2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
@@ -25,8 +25,8 @@ Configuration Microsoft_Windows_Server_2016_Member_Server_1607_CIS_L1_with_LAPS
         {
             cis2315AccountsRenameadministratoraccount = 'CISAdmin'
             cis2316AccountsRenameguestaccount = 'CISGuest'
-            a2375LegalNoticeCaption = 'Legal Notice'
-            a2374LegalNoticeText = @"
+            cis2375LegalNoticeCaption = 'Legal Notice'
+            cis2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
@@ -23,8 +23,8 @@ Configuration Microsoft_Windows_Server_2016_Member_Server_1607_CIS_L1_with_LAPS
 
         CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             a2375LegalNoticeCaption = 'Legal Notice'
             a2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
@@ -17,8 +17,8 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1
         {
             cis2315AccountsRenameadministratoraccount = 'CISAdmin'
             cis2316AccountsRenameguestaccount = 'CISGuest'
-            a2375LegalNoticeCaption = 'Legal Notice'
-            a2374LegalNoticeText = @"
+            cis2375LegalNoticeCaption = 'Legal Notice'
+            cis2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.ps1
@@ -15,8 +15,8 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1
     {
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             a2375LegalNoticeCaption = 'Legal Notice'
             a2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
@@ -25,8 +25,8 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1_with_LAPS
         {
             cis2315AccountsRenameadministratoraccount = 'CISAdmin'
             cis2316AccountsRenameguestaccount = 'CISGuest'
-            a2375LegalNoticeCaption = 'Legal Notice'
-            a2374LegalNoticeText = @"
+            cis2375LegalNoticeCaption = 'Legal Notice'
+            cis2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/Examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
@@ -23,8 +23,8 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1_with_LAPS
 
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 'CIS Benchmarks'
         {
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             a2375LegalNoticeCaption = 'Legal Notice'
             a2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
@@ -20,34 +20,34 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
     [ LevelTwo = [Boolean] ]
     [ BitLocker = [Boolean] ]
     [ NextGenerationWindowsSecurity = [Boolean] ]
-    [ a112MaximumPasswordAge = [Int32] { 60-999 } ]
-    [ a113MinimumPasswordAge = [Int32] { 1-998 } ]
+    [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
+    [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
     [ a114MinimumPasswordLength = [Int32] ]
-    [ a121Accountlockoutduration = [Int32] { 15-99999 } ]
-    [ a122Accountlockoutthreshold = [Int32] { 10-999 } ]
-    [ a123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
-    [ a1825PasswordLength = [Int32] { 15-64 } ]
-    [ a1826PasswordAgeDays = [Int32] { 30-365 } ]
-    [ a18410ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
-    [ a18413WarningLevel = [Int32] { 0-90 } ]
-    [ a18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
-    [ a1892612MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892622MaxSize = [Int32] { 196608-2147483647 } ]
-    [ a1892632MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892642MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a189593101MaxIdleTime = [Int32] { 60000-900000 } ]
-    [ a2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
-    [ a2316AccountsRenameguestaccount = [String] { 1-256 } ]
-    [ a2365MaximumPasswordAge = [Int32] { 1-30 } ]
-    [ a2373MaxDevicePasswordFailedAttempts = [Int32] { 1-10 } ]
-    [ a2374InactivityTimeoutSecs = [Int32] { 1-900 } ]
-    [ a2375LegalNoticeText = [String] { 1-2048 } ]
-    [ a2376LegalNoticeCaption = [String] { 1-512 } ]
-    [ a2377CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
-    [ a2391AutoDisconnect = [Int32] { 1-15 } ]
-    [ a916LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a926LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a938LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
+    [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
+    [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
+    [ cis1825PasswordLength = [Int32] { 15-64 } ]
+    [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
+    [ cis18410ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
+    [ cis18413WarningLevel = [Int32] { 0-90 } ]
+    [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
+    [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
+    [ cis1892632MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892642MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis189593101MaxIdleTime = [Int32] { 60000-900000 } ]
+    [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
+    [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
+    [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
+    [ cis2373MaxDevicePasswordFailedAttempts = [Int32] { 1-10 } ]
+    [ cis2374InactivityTimeoutSecs = [Int32] { 1-900 } ]
+    [ cis2375LegalNoticeText = [String] { 1-2048 } ]
+    [ cis2376LegalNoticeCaption = [String] { 1-512 } ]
+    [ cis2377CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
+    [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
+    [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis938LogFileSize = [Int32] { 16384-2147483647 } ]
     [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
@@ -57,10 +57,10 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
-> `a2315AccountsRenameadministratoraccount`,
-> `a2316AccountsRenameguestaccount`,
-> `a2376LegalNoticeCaption`,
-> `a2375LegalNoticeText`
+> `cis2315AccountsRenameadministratoraccount`,
+> `cis2316AccountsRenameguestaccount`,
+> `cis2376LegalNoticeCaption`,
+> `cis2375LegalNoticeText`
 ## Properties
 
 |Property |DefaultValue | Recommendation ID|Recommendation
@@ -70,34 +70,34 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
 |LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
 |BitLocker |`$false` | |Applies bitlocker recommendations |
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|a112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|a113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
+|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
+|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
 |a114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|a121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|a122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|a123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|a1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|a1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|a18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|a18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|a18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|a1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|a1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|a2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|a2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|a2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|a2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|a2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|a2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|a2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|a2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|a2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|a916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
+|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
+|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
+|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
+|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
+|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
+|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
+|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
+|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
+|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
+|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
+|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
+|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
+|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
+|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
+|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
+|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
+|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
+|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 
 ## Common properties
 
@@ -121,10 +121,10 @@ Configuration MyConfiguration
 
     CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CISBenchmarks'
     {
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
-        a2376LegalNoticeCaption = 'Legal Notice'
-        a2375LegalNoticeText = @"
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
+        cis2376LegalNoticeCaption = 'Legal Notice'
+        cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.
@@ -147,8 +147,8 @@ Configuration MyConfiguration
             '2.3.7.6', # LegalNoticeCaption
             '5.6' # IIS Admin Service (IISADMIN)
         )
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
     }
 }
 ```
@@ -176,8 +176,8 @@ Configuration MyConfiguration
                 '2.3.7.6', # LegalNoticeCaption
                 '5.6' # IIS Admin Service (IISADMIN)
             )
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             DependsOn = '[Package]InstallLAPS'
         }
     }

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
@@ -22,7 +22,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
     [ NextGenerationWindowsSecurity = [Boolean] ]
     [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
     [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
-    [ a114MinimumPasswordLength = [Int32] ]
+    [ cis114MinimumPasswordLength = [Int32] ]
     [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
     [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
     [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
@@ -72,7 +72,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
 |cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
 |cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|a114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
+|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
 |cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
 |cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
 |cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
@@ -22,7 +22,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
     [ NextGenerationWindowsSecurity = [Boolean] ]
     [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
     [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
-    [ a114MinimumPasswordLength = [Int32] ]
+    [ cis114MinimumPasswordLength = [Int32] ]
     [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
     [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
     [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
@@ -72,7 +72,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
 |cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
 |cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|a114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
+|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
 |cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
 |cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
 |cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
@@ -20,34 +20,34 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
     [ LevelTwo = [Boolean] ]
     [ BitLocker = [Boolean] ]
     [ NextGenerationWindowsSecurity = [Boolean] ]
-    [ a112MaximumPasswordAge = [Int32] { 60-999 } ]
-    [ a113MinimumPasswordAge = [Int32] { 1-998 } ]
+    [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
+    [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
     [ a114MinimumPasswordLength = [Int32] ]
-    [ a121Accountlockoutduration = [Int32] { 15-99999 } ]
-    [ a122Accountlockoutthreshold = [Int32] { 10-999 } ]
-    [ a123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
-    [ a1825PasswordLength = [Int32] { 15-64 } ]
-    [ a1826PasswordAgeDays = [Int32] { 30-365 } ]
-    [ a18410ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
-    [ a18413WarningLevel = [Int32] { 0-90 } ]
-    [ a18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
-    [ a1892612MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892622MaxSize = [Int32] { 196608-2147483647 } ]
-    [ a1892632MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892642MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a189593101MaxIdleTime = [Int32] { 60000-900000 } ]
-    [ a2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
-    [ a2316AccountsRenameguestaccount = [String] { 1-256 } ]
-    [ a2365MaximumPasswordAge = [Int32] { 1-30 } ]
-    [ a2373MaxDevicePasswordFailedAttempts = [Int32] { 1-10 } ]
-    [ a2374InactivityTimeoutSecs = [Int32] { 1-900 } ]
-    [ a2375LegalNoticeText = [String] { 1-2048 } ]
-    [ a2376LegalNoticeCaption = [String] { 1-512 } ]
-    [ a2377CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
-    [ a2391AutoDisconnect = [Int32] { 1-15 } ]
-    [ a916LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a926LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a938LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
+    [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
+    [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
+    [ cis1825PasswordLength = [Int32] { 15-64 } ]
+    [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
+    [ cis18410ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
+    [ cis18413WarningLevel = [Int32] { 0-90 } ]
+    [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
+    [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
+    [ cis1892632MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892642MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis189593101MaxIdleTime = [Int32] { 60000-900000 } ]
+    [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
+    [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
+    [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
+    [ cis2373MaxDevicePasswordFailedAttempts = [Int32] { 1-10 } ]
+    [ cis2374InactivityTimeoutSecs = [Int32] { 1-900 } ]
+    [ cis2375LegalNoticeText = [String] { 1-2048 } ]
+    [ cis2376LegalNoticeCaption = [String] { 1-512 } ]
+    [ cis2377CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
+    [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
+    [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis938LogFileSize = [Int32] { 16384-2147483647 } ]
     [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
@@ -57,10 +57,10 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
-> `a2315AccountsRenameadministratoraccount`,
-> `a2316AccountsRenameguestaccount`,
-> `a2376LegalNoticeCaption`,
-> `a2375LegalNoticeText`
+> `cis2315AccountsRenameadministratoraccount`,
+> `cis2316AccountsRenameguestaccount`,
+> `cis2376LegalNoticeCaption`,
+> `cis2375LegalNoticeText`
 ## Properties
 
 |Property |DefaultValue | Recommendation ID|Recommendation
@@ -70,34 +70,34 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
 |LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
 |BitLocker |`$false` | |Applies bitlocker recommendations |
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|a112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|a113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
+|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
+|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
 |a114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|a121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|a122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|a123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|a1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|a1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|a18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|a18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|a18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|a1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|a1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|a2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|a2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|a2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|a2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|a2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|a2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|a2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|a2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|a2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|a916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
+|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
+|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
+|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
+|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
+|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
+|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
+|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
+|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
+|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
+|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
+|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
+|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
+|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
+|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
+|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
+|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
+|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
+|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 
 ## Common properties
 
@@ -121,10 +121,10 @@ Configuration MyConfiguration
 
     CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CISBenchmarks'
     {
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
-        a2376LegalNoticeCaption = 'Legal Notice'
-        a2375LegalNoticeText = @"
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
+        cis2376LegalNoticeCaption = 'Legal Notice'
+        cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.
@@ -147,8 +147,8 @@ Configuration MyConfiguration
             '2.3.7.6', # LegalNoticeCaption
             '5.6' # IIS Admin Service (IISADMIN)
         )
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
     }
 }
 ```
@@ -176,8 +176,8 @@ Configuration MyConfiguration
                 '2.3.7.6', # LegalNoticeCaption
                 '5.6' # IIS Admin Service (IISADMIN)
             )
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             DependsOn = '[Package]InstallLAPS'
         }
     }

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
@@ -22,7 +22,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
     [ NextGenerationWindowsSecurity = [Boolean] ]
     [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
     [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
-    [ a114MinimumPasswordLength = [Int32] { 14-128 } ]
+    [ cis114MinimumPasswordLength = [Int32] { 14-128 } ]
     [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
     [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
     [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
@@ -35,7 +35,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
     [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
     [ cis1892632MaxSize = [Int32] { 32768-2147483647 } ]
     [ cis1892642MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a189623101MaxIdleTime = [Int32] { 60000-900000 } ]
+    [ cis189623101MaxIdleTime = [Int32] { 60000-900000 } ]
     [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
     [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
     [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
@@ -72,7 +72,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
 |cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
 |cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|a114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
+|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
 |cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
 |cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
 |cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
@@ -85,7 +85,7 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
 |cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
 |cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
 |cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a189623101MaxIdleTime |900000 |18.9.62.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
+|cis189623101MaxIdleTime |900000 |18.9.62.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
 |cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
 |cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
 |cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
@@ -20,34 +20,34 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
     [ LevelTwo = [Boolean] ]
     [ BitLocker = [Boolean] ]
     [ NextGenerationWindowsSecurity = [Boolean] ]
-    [ a112MaximumPasswordAge = [Int32] { 60-999 } ]
-    [ a113MinimumPasswordAge = [Int32] { 1-998 } ]
+    [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
+    [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
     [ a114MinimumPasswordLength = [Int32] { 14-128 } ]
-    [ a121Accountlockoutduration = [Int32] { 15-99999 } ]
-    [ a122Accountlockoutthreshold = [Int32] { 10-999 } ]
-    [ a123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
-    [ a1825PasswordLength = [Int32] { 15-64 } ]
-    [ a1826PasswordAgeDays = [Int32] { 30-365 } ]
-    [ a18410ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
-    [ a18413WarningLevel = [Int32] { 0-90 } ]
-    [ a18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
-    [ a1892612MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892622MaxSize = [Int32] { 196608-2147483647 } ]
-    [ a1892632MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892642MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
+    [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
+    [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
+    [ cis1825PasswordLength = [Int32] { 15-64 } ]
+    [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
+    [ cis18410ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
+    [ cis18413WarningLevel = [Int32] { 0-90 } ]
+    [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
+    [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
+    [ cis1892632MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892642MaxSize = [Int32] { 32768-2147483647 } ]
     [ a189623101MaxIdleTime = [Int32] { 60000-900000 } ]
-    [ a2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
-    [ a2316AccountsRenameguestaccount = [String] { 1-256 } ]
-    [ a2365MaximumPasswordAge = [Int32] { 1-30 } ]
-    [ a2373MaxDevicePasswordFailedAttempts = [Int32] { 1-10 } ]
-    [ a2374InactivityTimeoutSecs = [Int32] { 1-900 } ]
-    [ a2375LegalNoticeText = [String] { 1-2048 } ]
-    [ a2376LegalNoticeCaption = [String] { 1-512 } ]
-    [ a2377CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
-    [ a2391AutoDisconnect = [Int32] { 1-15 } ]
-    [ a916LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a926LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a938LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
+    [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
+    [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
+    [ cis2373MaxDevicePasswordFailedAttempts = [Int32] { 1-10 } ]
+    [ cis2374InactivityTimeoutSecs = [Int32] { 1-900 } ]
+    [ cis2375LegalNoticeText = [String] { 1-2048 } ]
+    [ cis2376LegalNoticeCaption = [String] { 1-512 } ]
+    [ cis2377CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
+    [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
+    [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis938LogFileSize = [Int32] { 16384-2147483647 } ]
     [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
@@ -57,10 +57,10 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
-> `a2315AccountsRenameadministratoraccount`,
-> `a2316AccountsRenameguestaccount`,
-> `a2376LegalNoticeCaption`,
-> `a2375LegalNoticeText`
+> `cis2315AccountsRenameadministratoraccount`,
+> `cis2316AccountsRenameguestaccount`,
+> `cis2376LegalNoticeCaption`,
+> `cis2375LegalNoticeText`
 ## Properties
 
 |Property |DefaultValue | Recommendation ID|Recommendation
@@ -70,34 +70,34 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
 |LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
 |BitLocker |`$false` | |Applies bitlocker recommendations |
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|a112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|a113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
+|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
+|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
 |a114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|a121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|a122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|a123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|a1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|a1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|a18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|a18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|a18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|a1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|a1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
+|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
+|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
+|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
+|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
+|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
+|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
+|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
+|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
 |a189623101MaxIdleTime |900000 |18.9.62.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|a2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|a2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|a2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|a2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|a2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|a2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|a2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|a2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|a2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|a916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
+|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
+|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
+|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
+|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
+|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
+|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
+|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
+|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
+|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 
 ## Common properties
 
@@ -121,10 +121,10 @@ Configuration MyConfiguration
 
     CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CISBenchmarks'
     {
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
-        a2376LegalNoticeCaption = 'Legal Notice'
-        a2375LegalNoticeText = @"
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
+        cis2376LegalNoticeCaption = 'Legal Notice'
+        cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.
@@ -147,8 +147,8 @@ Configuration MyConfiguration
             '2.3.7.6', # LegalNoticeCaption
             '5.6' # IIS Admin Service (IISADMIN)
         )
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
     }
 }
 ```
@@ -176,8 +176,8 @@ Configuration MyConfiguration
                 '2.3.7.6', # LegalNoticeCaption
                 '5.6' # IIS Admin Service (IISADMIN)
             )
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             DependsOn = '[Package]InstallLAPS'
         }
     }

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
@@ -26,8 +26,8 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
     [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
     [ cis1825PasswordLength = [Int32] { 15-64 } ]
     [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
-    [ a18412WarningLevel = [Int32] { 0-90 } ]
-    [ a1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
+    [ cis18412WarningLevel = [Int32] { 0-90 } ]
+    [ cis1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
     [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
     [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
     [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
@@ -37,10 +37,10 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
     [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
     [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
     [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
-    [ a2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
-    [ a2374LegalNoticeText = [String] { 1-2048 } ]
-    [ a2375LegalNoticeCaption = [String] { 1-512 } ]
-    [ a2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
+    [ cis2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
+    [ cis2374LegalNoticeText = [String] { 1-2048 } ]
+    [ cis2375LegalNoticeCaption = [String] { 1-512 } ]
+    [ cis2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
     [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
     [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
     [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
@@ -73,8 +73,8 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
 |cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
 |cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
 |cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
-|a18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|a1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+|cis18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
+|cis1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
 |cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
 |cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
 |cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
@@ -84,10 +84,10 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
 |cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
 |cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
 |cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|a2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|a2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|a2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|a2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
+|cis2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
+|cis2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
+|cis2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
+|cis2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
 |cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
 |cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 |cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
@@ -19,32 +19,32 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
     [ LevelOne = [Boolean] ]
     [ LevelTwo = [Boolean] ]
     [ NextGenerationWindowsSecurity = [Boolean] ]
-    [ a112MaximumPasswordAge = [Int32] { 60-999 } ]
-    [ a113MinimumPasswordAge = [Int32] { 1-998 } ]
-    [ a121Accountlockoutduration = [Int32] { 15-99999 } ]
-    [ a122Accountlockoutthreshold = [Int32] { 10-999 } ]
-    [ a123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
-    [ a1825PasswordLength = [Int32] { 15-64 } ]
-    [ a1826PasswordAgeDays = [Int32] { 30-365 } ]
+    [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
+    [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
+    [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
+    [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
+    [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
+    [ cis1825PasswordLength = [Int32] { 15-64 } ]
+    [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
     [ a18412WarningLevel = [Int32] { 0-90 } ]
     [ a1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
-    [ a18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
-    [ a1892612MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892622MaxSize = [Int32] { 196608-2147483647 } ]
-    [ a1892632MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892642MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a189593101MaxIdleTime = [Int32] { 60000-900000 } ]
-    [ a2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
-    [ a2316AccountsRenameguestaccount = [String] { 1-256 } ]
-    [ a2365MaximumPasswordAge = [Int32] { 1-30 } ]
+    [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
+    [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
+    [ cis1892632MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892642MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis189593101MaxIdleTime = [Int32] { 60000-900000 } ]
+    [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
+    [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
+    [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
     [ a2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
     [ a2374LegalNoticeText = [String] { 1-2048 } ]
     [ a2375LegalNoticeCaption = [String] { 1-512 } ]
     [ a2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
-    [ a2391AutoDisconnect = [Int32] { 1-15 } ]
-    [ a916LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a926LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a938LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
+    [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis938LogFileSize = [Int32] { 16384-2147483647 } ]
     [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
@@ -54,10 +54,10 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
-> `a2315AccountsRenameadministratoraccount`,
-> `a2316AccountsRenameguestaccount`,
-> `a2376LegalNoticeCaption`,
-> `a2375LegalNoticeText`
+> `cis2315AccountsRenameadministratoraccount`,
+> `cis2316AccountsRenameguestaccount`,
+> `cis2376LegalNoticeCaption`,
+> `cis2375LegalNoticeText`
 ## Properties
 
 |Property |DefaultValue | Recommendation ID|Recommendation
@@ -66,32 +66,32 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
 |LevelOne |`$true` | |Applies level one recommendations |
 |LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|a112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|a113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|a121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|a122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|a123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|a1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
-|a1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
+|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
+|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
+|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
+|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
+|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
+|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
+|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
 |a18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
 |a1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|a18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|a1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|a1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|a2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|a2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|a2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
+|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
+|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
+|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
+|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
+|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
+|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
 |a2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
 |a2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
 |a2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
 |a2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
-|a2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|a916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
+|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 
 ## Common properties
 
@@ -115,10 +115,10 @@ Configuration MyConfiguration
 
     CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 'CISBenchmarks'
     {
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
-        a2376LegalNoticeCaption = 'Legal Notice'
-        a2375LegalNoticeText = @"
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
+        cis2376LegalNoticeCaption = 'Legal Notice'
+        cis2375LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.
@@ -141,8 +141,8 @@ Configuration MyConfiguration
             '2.3.7.6', # LegalNoticeCaption
             '5.6' # IIS Admin Service (IISADMIN)
         )
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
     }
 }
 ```
@@ -170,8 +170,8 @@ Configuration MyConfiguration
                 '2.3.7.6', # LegalNoticeCaption
                 '5.6' # IIS Admin Service (IISADMIN)
             )
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             DependsOn = '[Package]InstallLAPS'
         }
     }

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
@@ -19,32 +19,32 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
     [ LevelOne = [Boolean] ]
     [ LevelTwo = [Boolean] ]
     [ NextGenerationWindowsSecurity = [Boolean] ]
-    [ a112MaximumPasswordAge = [Int32] { 60-999 } ]
-    [ a113MinimumPasswordAge = [Int32] { 1-998 } ]
-    [ a121Accountlockoutduration = [Int32] { 15-99999 } ]
-    [ a122Accountlockoutthreshold = [Int32] { 10-999 } ]
-    [ a123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
-    [ a1825PasswordLength = [Int32] { 15-64 } ]
-    [ a1826PasswordAgeDays = [Int32] { 30-365 } ]
+    [ cis112MaximumPasswordAge = [Int32] { 60-999 } ]
+    [ cis113MinimumPasswordAge = [Int32] { 1-998 } ]
+    [ cis121Accountlockoutduration = [Int32] { 15-99999 } ]
+    [ cis122Accountlockoutthreshold = [Int32] { 10-999 } ]
+    [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
+    [ cis1825PasswordLength = [Int32] { 15-64 } ]
+    [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
     [ a18412WarningLevel = [Int32] { 0-90 } ]
     [ a1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
-    [ a18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
-    [ a1892612MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892622MaxSize = [Int32] { 196608-2147483647 } ]
-    [ a1892632MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a1892642MaxSize = [Int32] { 32768-2147483647 } ]
-    [ a189593101MaxIdleTime = [Int32] { 60000-900000 } ]
-    [ a2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
-    [ a2316AccountsRenameguestaccount = [String] { 1-256 } ]
-    [ a2365MaximumPasswordAge = [Int32] { 1-30 } ]
+    [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
+    [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
+    [ cis1892632MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis1892642MaxSize = [Int32] { 32768-2147483647 } ]
+    [ cis189593101MaxIdleTime = [Int32] { 60000-900000 } ]
+    [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
+    [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
+    [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
     [ a2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
     [ a2374LegalNoticeText = [String] { 1-2048 } ]
     [ a2375LegalNoticeCaption = [String] { 1-512 } ]
     [ a2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
-    [ a2391AutoDisconnect = [Int32] { 1-15 } ]
-    [ a916LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a926LogFileSize = [Int32] { 16384-2147483647 } ]
-    [ a938LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
+    [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
+    [ cis938LogFileSize = [Int32] { 16384-2147483647 } ]
     [ DependsOn = [String[]] ]
     [ PsDscRunAsCredential = [PSCredential] ]
 }
@@ -54,8 +54,8 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
-> `a2315AccountsRenameadministratoraccount`,
-> `a2316AccountsRenameguestaccount`,
+> `cis2315AccountsRenameadministratoraccount`,
+> `cis2316AccountsRenameguestaccount`,
 > `a2375LegalNoticeCaption`,
 > `a2374LegalNoticeText`
 ## Properties
@@ -66,32 +66,32 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
 |LevelOne |`$true` | |Applies level one recommendations |
 |LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
 |NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|a112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|a113MinimumPasswordAge |30 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|a121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|a122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|a123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|a1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
-|a1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
+|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
+|cis113MinimumPasswordAge |30 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
+|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
+|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
+|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
+|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
+|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
 |a18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
 |a1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|a18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|a1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|a1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|a189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|a2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|a2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|a2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
+|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
+|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
+|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
+|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
+|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
+|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
+|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
 |a2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
 |a2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
 |a2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
 |a2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
-|a2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|a916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|a938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
+|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 
 ## Common properties
 
@@ -115,8 +115,8 @@ Configuration MyConfiguration
 
     CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 'CISBenchmarks'
     {
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
         a2375LegalNoticeCaption = 'Legal Notice'
         a2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
@@ -141,8 +141,8 @@ Configuration MyConfiguration
             '2.3.7.5', # LegalNoticeCaption
             '5.6' # IIS Admin Service (IISADMIN)
         )
-        a2315AccountsRenameadministratoraccount = 'CISAdmin'
-        a2316AccountsRenameguestaccount = 'CISGuest'
+        cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+        cis2316AccountsRenameguestaccount = 'CISGuest'
     }
 }
 ```
@@ -170,8 +170,8 @@ Configuration MyConfiguration
                 '2.3.7.5', # LegalNoticeCaption
                 '5.6' # IIS Admin Service (IISADMIN)
             )
-            a2315AccountsRenameadministratoraccount = 'CISAdmin'
-            a2316AccountsRenameguestaccount = 'CISGuest'
+            cis2315AccountsRenameadministratoraccount = 'CISAdmin'
+            cis2316AccountsRenameguestaccount = 'CISGuest'
             DependsOn = '[Package]InstallLAPS'
         }
     }

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
@@ -26,8 +26,8 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
     [ cis123Resetaccountlockoutcounterafter = [Int32] { 15-99999 } ]
     [ cis1825PasswordLength = [Int32] { 15-64 } ]
     [ cis1826PasswordAgeDays = [Int32] { 30-365 } ]
-    [ a18412WarningLevel = [Int32] { 0-90 } ]
-    [ a1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
+    [ cis18412WarningLevel = [Int32] { 0-90 } ]
+    [ cis1849ScreenSaverGracePeriod = [String] { '0' | '1' | '2' | '3' | '4' | '5' } ]
     [ cis18910212DeferFeatureUpdatesPeriodInDays = [Int32] { 180-365 } ]
     [ cis1892612MaxSize = [Int32] { 32768-2147483647 } ]
     [ cis1892622MaxSize = [Int32] { 196608-2147483647 } ]
@@ -37,10 +37,10 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
     [ cis2315AccountsRenameadministratoraccount = [String] { 1-256 } ]
     [ cis2316AccountsRenameguestaccount = [String] { 1-256 } ]
     [ cis2365MaximumPasswordAge = [Int32] { 1-30 } ]
-    [ a2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
-    [ a2374LegalNoticeText = [String] { 1-2048 } ]
-    [ a2375LegalNoticeCaption = [String] { 1-512 } ]
-    [ a2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
+    [ cis2373InactivityTimeoutSecs = [Int32] { 1-900 } ]
+    [ cis2374LegalNoticeText = [String] { 1-2048 } ]
+    [ cis2375LegalNoticeCaption = [String] { 1-512 } ]
+    [ cis2376CachedLogonsCount = [String] { '0' | '1' | '2' | '3' | '4' } ]
     [ cis2391AutoDisconnect = [Int32] { 1-15 } ]
     [ cis916LogFileSize = [Int32] { 16384-2147483647 } ]
     [ cis926LogFileSize = [Int32] { 16384-2147483647 } ]
@@ -56,8 +56,8 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
 > `cis2315AccountsRenameadministratoraccount`,
 > `cis2316AccountsRenameguestaccount`,
-> `a2375LegalNoticeCaption`,
-> `a2374LegalNoticeText`
+> `cis2375LegalNoticeCaption`,
+> `cis2374LegalNoticeText`
 ## Properties
 
 |Property |DefaultValue | Recommendation ID|Recommendation
@@ -73,8 +73,8 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
 |cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
 |cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
 |cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
-|a18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|a1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+|cis18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
+|cis1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
 |cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
 |cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
 |cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
@@ -84,10 +84,10 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
 |cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
 |cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
 |cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|a2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|a2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|a2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|a2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
+|cis2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
+|cis2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
+|cis2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
+|cis2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
 |cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
 |cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
 |cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
@@ -117,8 +117,8 @@ Configuration MyConfiguration
     {
         cis2315AccountsRenameadministratoraccount = 'CISAdmin'
         cis2316AccountsRenameguestaccount = 'CISGuest'
-        a2375LegalNoticeCaption = 'Legal Notice'
-        a2374LegalNoticeText = @"
+        cis2375LegalNoticeCaption = 'Legal Notice'
+        cis2374LegalNoticeText = @"
 This is a super secure device that we don't want bad people using.
 I'm even making sure to put this as a literal string so that I can cleanly
 use multiple lines to tell you how super secure it is.

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1809/CIS_Microsoft_Windows_10_Enterprise_Release_1809.schema.psm1
@@ -8,59 +8,59 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         [Boolean]$BitLocker = $false,
         [Boolean]$NextGenerationWindowsSecurity = $false,
         [ValidateRange(60,999)]
-        [Int32]$a112MaximumPasswordAge = 60,
+        [Int32]$cis112MaximumPasswordAge = 60,
         [ValidateRange(1,998)]
-        [Int32]$a113MinimumPasswordAge = 1,
+        [Int32]$cis113MinimumPasswordAge = 1,
         [ValidateRange(15,99999)]
-        [Int32]$a121Accountlockoutduration = 15,
+        [Int32]$cis121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
-        [Int32]$a122Accountlockoutthreshold = 10,
+        [Int32]$cis122Accountlockoutthreshold = 10,
         [ValidateRange(15,99999)]
-        [Int32]$a123Resetaccountlockoutcounterafter = 15,
+        [Int32]$cis123Resetaccountlockoutcounterafter = 15,
         [ValidateRange(15,64)]
-        [Int32]$a1825PasswordLength = 15,
+        [Int32]$cis1825PasswordLength = 15,
         [ValidateRange(30,365)]
-        [Int32]$a1826PasswordAgeDays = 30,
+        [Int32]$cis1826PasswordAgeDays = 30,
         [ValidateSet('0','1','2','3','4','5')]
-        [String]$a18410ScreenSaverGracePeriod = '0',
+        [String]$cis18410ScreenSaverGracePeriod = '0',
         [ValidateRange(0,90)]
-        [Int32]$a18413WarningLevel = 90,
+        [Int32]$cis18413WarningLevel = 90,
         [ValidateRange(180,365)]
-        [Int32]$a18910212DeferFeatureUpdatesPeriodInDays = 180,
+        [Int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892612MaxSize = 32768,
+        [Int32]$cis1892612MaxSize = 32768,
         [ValidateRange(196608,2147483647)]
-        [Int32]$a1892622MaxSize = 196608,
+        [Int32]$cis1892622MaxSize = 196608,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892632MaxSize = 32768,
+        [Int32]$cis1892632MaxSize = 32768,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892642MaxSize = 32768,
+        [Int32]$cis1892642MaxSize = 32768,
         [ValidateRange(60000,900000)]
-        [Int32]$a189593101MaxIdleTime = 900000,
+        [Int32]$cis189593101MaxIdleTime = 900000,
         [ValidateLength(1,256)]
-        [String]$a2315AccountsRenameadministratoraccount,
+        [String]$cis2315AccountsRenameadministratoraccount,
         [ValidateLength(1,256)]
-        [String]$a2316AccountsRenameguestaccount,
+        [String]$cis2316AccountsRenameguestaccount,
         [ValidateRange(1,30)]
-        [Int32]$a2365MaximumPasswordAge = 30,
+        [Int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,10)]
-        [Int32]$a2373MaxDevicePasswordFailedAttempts = 10,
+        [Int32]$cis2373MaxDevicePasswordFailedAttempts = 10,
         [ValidateRange(1,900)]
-        [Int32]$a2374InactivityTimeoutSecs = 900,
+        [Int32]$cis2374InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
-        [String]$a2375LegalNoticeText,
+        [String]$cis2375LegalNoticeText,
         [ValidateLength(1,512)]
-        [String]$a2376LegalNoticeCaption,
+        [String]$cis2376LegalNoticeCaption,
         [ValidateSet('0','1','2','3','4')]
-        [String]$a2377CachedLogonsCount = '4',
+        [String]$cis2377CachedLogonsCount = '4',
         [ValidateLength(1,15)]
-        [Int32]$a2391AutoDisconnect = 15,
+        [Int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a916LogFileSize = 16384,
+        [Int32]$cis916LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a926LogFileSize = 16384,
+        [Int32]$cis926LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a938LogFileSize = 16384
+        [Int32]$cis938LogFileSize = 16384
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
@@ -68,17 +68,17 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
-    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'a2315AccountsRenameadministratoraccount'){
-        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "a2315AccountsRenameadministratoraccount"'
+    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'cis2315AccountsRenameadministratoraccount'){
+        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "cis2315AccountsRenameadministratoraccount"'
     }
-    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'a2316AccountsRenameguestaccount'){
-        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "a2316AccountsRenameguestaccount"'
+    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
+        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
-    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'a2375LegalNoticeText'){
-        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "a2375LegalNoticeText"'
+    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'cis2375LegalNoticeText'){
+        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "cis2375LegalNoticeText"'
     }
-    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains 'a2376LegalNoticeCaption'){
-        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "a2376LegalNoticeCaption"'
+    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains 'cis2376LegalNoticeCaption'){
+        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "cis2376LegalNoticeCaption"'
     }
 
     if($ExcludeList -notcontains '1.1.1' -and $LevelOne){
@@ -89,13 +89,13 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     }
     if($ExcludeList -notcontains '1.1.2' -and $LevelOne){
         AccountPolicy "1.1.2 - (L1) Ensure Maximum password age is set to 60 or fewer days but not 0" {
-            Maximum_Password_Age = $a112MaximumPasswordAge
+            Maximum_Password_Age = $cis112MaximumPasswordAge
             Name = 'Maximum_Password_Age'
         }
     }
     if($ExcludeList -notcontains '1.1.3' -and $LevelOne){
         AccountPolicy "1.1.3 - (L1) Ensure Minimum password age is set to 1 or more day(s)" {
-            Minimum_Password_Age = $a113MinimumPasswordAge
+            Minimum_Password_Age = $cis113MinimumPasswordAge
             Name = 'Minimum_Password_Age'
         }
     }
@@ -119,20 +119,20 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     }
     if($ExcludeList -notcontains '1.2.1' -and $LevelOne){
         AccountPolicy "1.2.1 - (L1) Ensure Account lockout duration is set to 15 or more minute(s)" {
-            Account_lockout_duration = $a121Accountlockoutduration
+            Account_lockout_duration = $cis121Accountlockoutduration
             Name = 'Account_lockout_duration'
         }
     }
     if($ExcludeList -notcontains '1.2.2' -and $LevelOne){
         AccountPolicy "1.2.2 - (L1) Ensure Account lockout threshold is set to 10 or fewer invalid logon attempt(s) but not 0" {
-            Account_lockout_threshold = $a122Accountlockoutthreshold
+            Account_lockout_threshold = $cis122Accountlockoutthreshold
             Name = 'Account_lockout_threshold'
         }
     }
     if($ExcludeList -notcontains '1.2.3' -and $LevelOne){
         AccountPolicy "1.2.3 - (L1) Ensure Reset account lockout counter after is set to 15 or more minute(s)" {
             Name = 'Reset_account_lockout_counter_after'
-            Reset_account_lockout_counter_after = $a123Resetaccountlockoutcounterafter
+            Reset_account_lockout_counter_after = $cis123Resetaccountlockoutcounterafter
         }
     }
     if($ExcludeList -notcontains '2.2.1' -and $LevelOne){
@@ -438,13 +438,13 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     }
     if($ExcludeList -notcontains '2.3.1.5' -and $LevelOne){
         SecurityOption "2.3.1.5 - (L1) Configure Accounts Rename administrator account" {
-            Accounts_Rename_administrator_account = $a2315AccountsRenameadministratoraccount
+            Accounts_Rename_administrator_account = $cis2315AccountsRenameadministratoraccount
             Name = 'Accounts_Rename_administrator_account'
         }
     }
     if($ExcludeList -notcontains '2.3.1.6' -and $LevelOne){
         SecurityOption "2.3.1.6 - (L1) Configure Accounts Rename guest account" {
-            Accounts_Rename_guest_account = $a2316AccountsRenameguestaccount
+            Accounts_Rename_guest_account = $cis2316AccountsRenameguestaccount
             Name = 'Accounts_Rename_guest_account'
         }
     }
@@ -515,7 +515,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.6.5' -and $LevelOne){
         Registry "2.3.6.5 - (L1) Ensure Domain member Maximum machine account password age is set to 30 or fewer days but not 0" {
             Key = 'HKLM:\System\CurrentControlSet\Services\Netlogon\Parameters'
-            ValueData = $a2365MaximumPasswordAge
+            ValueData = $cis2365MaximumPasswordAge
             ValueName = 'MaximumPasswordAge'
             ValueType = 'Dword'
         }
@@ -547,7 +547,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.7.3' -and $BitLocker){
         Registry "2.3.7.3 - (BL) Ensure Interactive logon Machine account lockout threshold is set to 10 or fewer invalid logon attempts but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2373MaxDevicePasswordFailedAttempts
+            ValueData = $cis2373MaxDevicePasswordFailedAttempts
             ValueName = 'MaxDevicePasswordFailedAttempts'
             ValueType = 'Dword'
         }
@@ -555,7 +555,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.7.4' -and $LevelOne){
         Registry "2.3.7.4 - (L1) Ensure Interactive logon Machine inactivity limit is set to 900 or fewer second(s) but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2374InactivityTimeoutSecs
+            ValueData = $cis2374InactivityTimeoutSecs
             ValueName = 'InactivityTimeoutSecs'
             ValueType = 'Dword'
         }
@@ -563,7 +563,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.7.5' -and $LevelOne){
         Registry "2.3.7.5 - (L1) Configure Interactive logon Message text for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2375LegalNoticeText
+            ValueData = $cis2375LegalNoticeText
             ValueName = 'LegalNoticeText'
             ValueType = 'String'
         }
@@ -571,7 +571,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.7.6' -and $LevelOne){
         Registry "2.3.7.6 - (L1) Configure Interactive logon Message title for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2376LegalNoticeCaption
+            ValueData = $cis2376LegalNoticeCaption
             ValueName = 'LegalNoticeCaption'
             ValueType = 'String'
         }
@@ -579,7 +579,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.7.7' -and $LevelTwo){
         Registry "2.3.7.7 - (L2) Ensure Interactive logon Number of previous logons to cache (in case domain controller is not available) is set to 4 or fewer logon(s)" {
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a2377CachedLogonsCount
+            ValueData = $cis2377CachedLogonsCount
             ValueName = 'CachedLogonsCount'
             ValueType = 'String'
         }
@@ -627,7 +627,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
     if($ExcludeList -notcontains '2.3.9.1' -and $LevelOne){
         Registry "2.3.9.1 - (L1) Ensure Microsoft network server Amount of idle time required before suspending session is set to 15 or fewer minute(s)" {
             Key = 'HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters'
-            ValueData = $a2391AutoDisconnect
+            ValueData = $cis2391AutoDisconnect
             ValueName = 'AutoDisconnect'
             ValueType = 'Dword'
         }
@@ -1193,7 +1193,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "9.1.6 - (L1) Ensure Windows Firewall Domain Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging'
-            ValueData = $a916LogFileSize
+            ValueData = $cis916LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1265,7 +1265,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "9.2.6 - (L1) Ensure Windows Firewall Private Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging'
-            ValueData = $a926LogFileSize
+            ValueData = $cis926LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1355,7 +1355,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "9.3.8 - (L1) Ensure Windows Firewall Public Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging'
-            ValueData = $a938LogFileSize
+            ValueData = $cis938LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1769,7 +1769,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.2.5 - (L1) Ensure Password Settings Password Length is set to Enabled 15 or more" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1825PasswordLength
+            ValueData = $cis1825PasswordLength
             ValueName = 'PasswordLength'
             ValueType = 'Dword'
         }
@@ -1778,7 +1778,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.2.6 - (L1) Ensure Password Settings Password Age (Days) is set to Enabled 30 or fewer" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1826PasswordAgeDays
+            ValueData = $cis1826PasswordAgeDays
             ValueName = 'PasswordAgeDays'
             ValueType = 'Dword'
         }
@@ -1913,7 +1913,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.4.10 - (L1) Ensure MSS (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) is set to Enabled 5 or fewer seconds" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a18410ScreenSaverGracePeriod
+            ValueData = $cis18410ScreenSaverGracePeriod
             ValueName = 'ScreenSaverGracePeriod'
             ValueType = 'String'
         }
@@ -1940,7 +1940,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.4.13 - (L1) Ensure MSS (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning is set to Enabled 90 or less" {
             Ensure = 'Present'
             Key = 'HKLM:\SYSTEM\CurrentControlSet\Services\Eventlog\Security'
-            ValueData = $a18413WarningLevel
+            ValueData = $cis18413WarningLevel
             ValueName = 'WarningLevel'
             ValueType = 'Dword'
         }
@@ -3549,7 +3549,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.9.26.1.2 - (L1) Ensure Application Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\Application'
-            ValueData = $a1892612MaxSize
+            ValueData = $cis1892612MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3567,7 +3567,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.9.26.2.2 - (L1) Ensure Security Specify the maximum log file size (KB) is set to Enabled 196608 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\Security'
-            ValueData = $a1892622MaxSize
+            ValueData = $cis1892622MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3585,7 +3585,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.9.26.3.2 - (L1) Ensure Setup Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\Setup'
-            ValueData = $a1892632MaxSize
+            ValueData = $cis1892632MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3603,7 +3603,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.9.26.4.2 - (L1) Ensure System Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\System'
-            ValueData = $a1892642MaxSize
+            ValueData = $cis1892642MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3900,7 +3900,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.9.59.3.10.1 - (L2) Ensure Set time limit for active but idle Remote Desktop Services sessions is set to Enabled 15 minutes or less" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
-            ValueData = $a189593101MaxIdleTime
+            ValueData = $cis189593101MaxIdleTime
             ValueName = 'MaxIdleTime'
             ValueType = 'Dword'
         }
@@ -4630,7 +4630,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1809
         Registry "18.9.102.1.2 - (L1) Ensure Select when Preview Builds and Feature Updates are received is set to Enabled Semi-Annual Channel 180 or more days (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate'
-            ValueData = $a18910212DeferFeatureUpdatesPeriodInDays
+            ValueData = $cis18910212DeferFeatureUpdatesPeriodInDays
             ValueName = 'DeferFeatureUpdatesPeriodInDays'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_1909/CIS_Microsoft_Windows_10_Enterprise_Release_1909.schema.psm1
@@ -8,59 +8,59 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         [Boolean]$BitLocker = $false,
         [Boolean]$NextGenerationWindowsSecurity = $false,
         [ValidateRange(60,999)]
-        [Int32]$a112MaximumPasswordAge = 60,
+        [Int32]$cis112MaximumPasswordAge = 60,
         [ValidateRange(1,998)]
-        [Int32]$a113MinimumPasswordAge = 1,
+        [Int32]$cis113MinimumPasswordAge = 1,
         [ValidateRange(15,99999)]
-        [Int32]$a121Accountlockoutduration = 15,
+        [Int32]$cis121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
-        [Int32]$a122Accountlockoutthreshold = 10,
+        [Int32]$cis122Accountlockoutthreshold = 10,
         [ValidateRange(15,99999)]
-        [Int32]$a123Resetaccountlockoutcounterafter = 15,
+        [Int32]$cis123Resetaccountlockoutcounterafter = 15,
         [ValidateRange(15,64)]
-        [Int32]$a1825PasswordLength = 15,
+        [Int32]$cis1825PasswordLength = 15,
         [ValidateRange(30,365)]
-        [Int32]$a1826PasswordAgeDays = 30,
+        [Int32]$cis1826PasswordAgeDays = 30,
         [ValidateSet('0','1','2','3','4','5')]
-        [String]$a18410ScreenSaverGracePeriod = '0',
+        [String]$cis18410ScreenSaverGracePeriod = '0',
         [ValidateRange(0,90)]
-        [Int32]$a18413WarningLevel = 90,
+        [Int32]$cis18413WarningLevel = 90,
         [ValidateRange(180,365)]
-        [Int32]$a18910212DeferFeatureUpdatesPeriodInDays = 180,
+        [Int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892612MaxSize = 32768,
+        [Int32]$cis1892612MaxSize = 32768,
         [ValidateRange(196608,2147483647)]
-        [Int32]$a1892622MaxSize = 196608,
+        [Int32]$cis1892622MaxSize = 196608,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892632MaxSize = 32768,
+        [Int32]$cis1892632MaxSize = 32768,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892642MaxSize = 32768,
+        [Int32]$cis1892642MaxSize = 32768,
         [ValidateRange(60000,900000)]
-        [Int32]$a189593101MaxIdleTime = 900000,
+        [Int32]$cis189593101MaxIdleTime = 900000,
         [ValidateLength(1,256)]
-        [String]$a2315AccountsRenameadministratoraccount,
+        [String]$cis2315AccountsRenameadministratoraccount,
         [ValidateLength(1,256)]
-        [String]$a2316AccountsRenameguestaccount,
+        [String]$cis2316AccountsRenameguestaccount,
         [ValidateRange(1,30)]
-        [Int32]$a2365MaximumPasswordAge = 30,
+        [Int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,10)]
-        [Int32]$a2373MaxDevicePasswordFailedAttempts = 10,
+        [Int32]$cis2373MaxDevicePasswordFailedAttempts = 10,
         [ValidateRange(1,900)]
-        [Int32]$a2374InactivityTimeoutSecs = 900,
+        [Int32]$cis2374InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
-        [String]$a2375LegalNoticeText,
+        [String]$cis2375LegalNoticeText,
         [ValidateLength(1,512)]
-        [String]$a2376LegalNoticeCaption,
+        [String]$cis2376LegalNoticeCaption,
         [ValidateSet('0','1','2','3','4')]
-        [String]$a2377CachedLogonsCount = '4',
+        [String]$cis2377CachedLogonsCount = '4',
         [ValidateLength(1,15)]
-        [Int32]$a2391AutoDisconnect = 15,
+        [Int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a916LogFileSize = 16384,
+        [Int32]$cis916LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a926LogFileSize = 16384,
+        [Int32]$cis926LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a938LogFileSize = 16384
+        [Int32]$cis938LogFileSize = 16384
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
@@ -68,17 +68,17 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
-    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'a2315AccountsRenameadministratoraccount'){
-        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "a2315AccountsRenameadministratoraccount"'
+    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'cis2315AccountsRenameadministratoraccount'){
+        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "cis2315AccountsRenameadministratoraccount"'
     }
-    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'a2316AccountsRenameguestaccount'){
-        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "a2316AccountsRenameguestaccount"'
+    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
+        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
-    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'a2375LegalNoticeText'){
-        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "a2375LegalNoticeText"'
+    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'cis2375LegalNoticeText'){
+        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "cis2375LegalNoticeText"'
     }
-    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains 'a2376LegalNoticeCaption'){
-        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "a2376LegalNoticeCaption"'
+    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains 'cis2376LegalNoticeCaption'){
+        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "cis2376LegalNoticeCaption"'
     }
 
     if($ExcludeList -notcontains '1.1.1' -and $LevelOne){
@@ -89,13 +89,13 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     }
     if($ExcludeList -notcontains '1.1.2' -and $LevelOne){
         AccountPolicy "1.1.2 - (L1) Ensure Maximum password age is set to 60 or fewer days but not 0" {
-            Maximum_Password_Age = $a112MaximumPasswordAge
+            Maximum_Password_Age = $cis112MaximumPasswordAge
             Name = 'Maximum_Password_Age'
         }
     }
     if($ExcludeList -notcontains '1.1.3' -and $LevelOne){
         AccountPolicy "1.1.3 - (L1) Ensure Minimum password age is set to 1 or more day(s)" {
-            Minimum_Password_Age = $a113MinimumPasswordAge
+            Minimum_Password_Age = $cis113MinimumPasswordAge
             Name = 'Minimum_Password_Age'
         }
     }
@@ -119,20 +119,20 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     }
     if($ExcludeList -notcontains '1.2.1' -and $LevelOne){
         AccountPolicy "1.2.1 - (L1) Ensure Account lockout duration is set to 15 or more minute(s)" {
-            Account_lockout_duration = $a121Accountlockoutduration
+            Account_lockout_duration = $cis121Accountlockoutduration
             Name = 'Account_lockout_duration'
         }
     }
     if($ExcludeList -notcontains '1.2.2' -and $LevelOne){
         AccountPolicy "1.2.2 - (L1) Ensure Account lockout threshold is set to 10 or fewer invalid logon attempt(s) but not 0" {
-            Account_lockout_threshold = $a122Accountlockoutthreshold
+            Account_lockout_threshold = $cis122Accountlockoutthreshold
             Name = 'Account_lockout_threshold'
         }
     }
     if($ExcludeList -notcontains '1.2.3' -and $LevelOne){
         AccountPolicy "1.2.3 - (L1) Ensure Reset account lockout counter after is set to 15 or more minute(s)" {
             Name = 'Reset_account_lockout_counter_after'
-            Reset_account_lockout_counter_after = $a123Resetaccountlockoutcounterafter
+            Reset_account_lockout_counter_after = $cis123Resetaccountlockoutcounterafter
         }
     }
     if($ExcludeList -notcontains '2.2.1' -and $LevelOne){
@@ -438,13 +438,13 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     }
     if($ExcludeList -notcontains '2.3.1.5' -and $LevelOne){
         SecurityOption "2.3.1.5 - (L1) Configure Accounts Rename administrator account" {
-            Accounts_Rename_administrator_account = $a2315AccountsRenameadministratoraccount
+            Accounts_Rename_administrator_account = $cis2315AccountsRenameadministratoraccount
             Name = 'Accounts_Rename_administrator_account'
         }
     }
     if($ExcludeList -notcontains '2.3.1.6' -and $LevelOne){
         SecurityOption "2.3.1.6 - (L1) Configure Accounts Rename guest account" {
-            Accounts_Rename_guest_account = $a2316AccountsRenameguestaccount
+            Accounts_Rename_guest_account = $cis2316AccountsRenameguestaccount
             Name = 'Accounts_Rename_guest_account'
         }
     }
@@ -515,7 +515,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.6.5' -and $LevelOne){
         Registry "2.3.6.5 - (L1) Ensure Domain member Maximum machine account password age is set to 30 or fewer days but not 0" {
             Key = 'HKLM:\System\CurrentControlSet\Services\Netlogon\Parameters'
-            ValueData = $a2365MaximumPasswordAge
+            ValueData = $cis2365MaximumPasswordAge
             ValueName = 'MaximumPasswordAge'
             ValueType = 'Dword'
         }
@@ -547,7 +547,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.7.3' -and $BitLocker){
         Registry "2.3.7.3 - (BL) Ensure Interactive logon Machine account lockout threshold is set to 10 or fewer invalid logon attempts but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2373MaxDevicePasswordFailedAttempts
+            ValueData = $cis2373MaxDevicePasswordFailedAttempts
             ValueName = 'MaxDevicePasswordFailedAttempts'
             ValueType = 'Dword'
         }
@@ -555,7 +555,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.7.4' -and $LevelOne){
         Registry "2.3.7.4 - (L1) Ensure Interactive logon Machine inactivity limit is set to 900 or fewer second(s) but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2374InactivityTimeoutSecs
+            ValueData = $cis2374InactivityTimeoutSecs
             ValueName = 'InactivityTimeoutSecs'
             ValueType = 'Dword'
         }
@@ -563,7 +563,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.7.5' -and $LevelOne){
         Registry "2.3.7.5 - (L1) Configure Interactive logon Message text for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2375LegalNoticeText
+            ValueData = $cis2375LegalNoticeText
             ValueName = 'LegalNoticeText'
             ValueType = 'String'
         }
@@ -571,7 +571,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.7.6' -and $LevelOne){
         Registry "2.3.7.6 - (L1) Configure Interactive logon Message title for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2376LegalNoticeCaption
+            ValueData = $cis2376LegalNoticeCaption
             ValueName = 'LegalNoticeCaption'
             ValueType = 'String'
         }
@@ -579,7 +579,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.7.7' -and $LevelTwo){
         Registry "2.3.7.7 - (L2) Ensure Interactive logon Number of previous logons to cache (in case domain controller is not available) is set to 4 or fewer logon(s)" {
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a2377CachedLogonsCount
+            ValueData = $cis2377CachedLogonsCount
             ValueName = 'CachedLogonsCount'
             ValueType = 'String'
         }
@@ -627,7 +627,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
     if($ExcludeList -notcontains '2.3.9.1' -and $LevelOne){
         Registry "2.3.9.1 - (L1) Ensure Microsoft network server Amount of idle time required before suspending session is set to 15 or fewer minute(s)" {
             Key = 'HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters'
-            ValueData = $a2391AutoDisconnect
+            ValueData = $cis2391AutoDisconnect
             ValueName = 'AutoDisconnect'
             ValueType = 'Dword'
         }
@@ -1193,7 +1193,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "9.1.6 - (L1) Ensure Windows Firewall Domain Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging'
-            ValueData = $a916LogFileSize
+            ValueData = $cis916LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1265,7 +1265,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "9.2.6 - (L1) Ensure Windows Firewall Private Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging'
-            ValueData = $a926LogFileSize
+            ValueData = $cis926LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1355,7 +1355,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "9.3.8 - (L1) Ensure Windows Firewall Public Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging'
-            ValueData = $a938LogFileSize
+            ValueData = $cis938LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1769,7 +1769,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.2.5 - (L1) Ensure Password Settings Password Length is set to Enabled 15 or more" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1825PasswordLength
+            ValueData = $cis1825PasswordLength
             ValueName = 'PasswordLength'
             ValueType = 'Dword'
         }
@@ -1778,7 +1778,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.2.6 - (L1) Ensure Password Settings Password Age (Days) is set to Enabled 30 or fewer" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1826PasswordAgeDays
+            ValueData = $cis1826PasswordAgeDays
             ValueName = 'PasswordAgeDays'
             ValueType = 'Dword'
         }
@@ -1922,7 +1922,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.4.10 - (L1) Ensure MSS (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) is set to Enabled 5 or fewer seconds" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a18410ScreenSaverGracePeriod
+            ValueData = $cis18410ScreenSaverGracePeriod
             ValueName = 'ScreenSaverGracePeriod'
             ValueType = 'String'
         }
@@ -1949,7 +1949,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.4.13 - (L1) Ensure MSS (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning is set to Enabled 90 or less" {
             Ensure = 'Present'
             Key = 'HKLM:\SYSTEM\CurrentControlSet\Services\Eventlog\Security'
-            ValueData = $a18413WarningLevel
+            ValueData = $cis18413WarningLevel
             ValueName = 'WarningLevel'
             ValueType = 'Dword'
         }
@@ -3551,7 +3551,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.9.26.1.2 - (L1) Ensure Application Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application'
-            ValueData = $a1892612MaxSize
+            ValueData = $cis1892612MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3569,7 +3569,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.9.26.2.2 - (L1) Ensure Security Specify the maximum log file size (KB) is set to Enabled 196608 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security'
-            ValueData = $a1892622MaxSize
+            ValueData = $cis1892622MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3587,7 +3587,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.9.26.3.2 - (L1) Ensure Setup Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup'
-            ValueData = $a1892632MaxSize
+            ValueData = $cis1892632MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3605,7 +3605,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.9.26.4.2 - (L1) Ensure System Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\System'
-            ValueData = $a1892642MaxSize
+            ValueData = $cis1892642MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3902,7 +3902,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.9.59.3.10.1 - (L2) Ensure Set time limit for active but idle Remote Desktop Services sessions is set to Enabled 15 minutes or less" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
-            ValueData = $a189593101MaxIdleTime
+            ValueData = $cis189593101MaxIdleTime
             ValueName = 'MaxIdleTime'
             ValueType = 'Dword'
         }
@@ -4632,7 +4632,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_1909
         Registry "18.9.102.1.2 - (L1) Ensure Select when Preview Builds and Feature Updates are received is set to Enabled Semi-Annual Channel 180 or more days (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate'
-            ValueData = $a18910212DeferFeatureUpdatesPeriodInDays
+            ValueData = $cis18910212DeferFeatureUpdatesPeriodInDays
             ValueName = 'DeferFeatureUpdatesPeriodInDays'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -8,61 +8,61 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         [Boolean]$BitLocker = $false,
         [Boolean]$NextGenerationWindowsSecurity = $false,
         [ValidateRange(60,999)]
-        [Int32]$a112MaximumPasswordAge = 60,
+        [Int32]$cis112MaximumPasswordAge = 60,
         [ValidateRange(1,998)]
-        [Int32]$a113MinimumPasswordAge = 1,
+        [Int32]$cis113MinimumPasswordAge = 1,
         [ValidateRange(14,128)]
         [Int32]$a114MinimumPasswordLength = 14,
         [ValidateRange(15,99999)]
-        [Int32]$a121Accountlockoutduration = 15,
+        [Int32]$cis121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
-        [Int32]$a122Accountlockoutthreshold = 10,
+        [Int32]$cis122Accountlockoutthreshold = 10,
         [ValidateRange(15,99999)]
-        [Int32]$a123Resetaccountlockoutcounterafter = 15,
+        [Int32]$cis123Resetaccountlockoutcounterafter = 15,
         [ValidateRange(15,64)]
-        [Int32]$a1825PasswordLength = 15,
+        [Int32]$cis1825PasswordLength = 15,
         [ValidateRange(30,365)]
-        [Int32]$a1826PasswordAgeDays = 30,
+        [Int32]$cis1826PasswordAgeDays = 30,
         [ValidateSet('0','1','2','3','4','5')]
-        [String]$a18410ScreenSaverGracePeriod = '0',
+        [String]$cis18410ScreenSaverGracePeriod = '0',
         [ValidateRange(0,90)]
-        [Int32]$a18413WarningLevel = 90,
+        [Int32]$cis18413WarningLevel = 90,
         [ValidateRange(180,365)]
-        [Int32]$a18910212DeferFeatureUpdatesPeriodInDays = 180,
+        [Int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892612MaxSize = 32768,
+        [Int32]$cis1892612MaxSize = 32768,
         [ValidateRange(196608,2147483647)]
-        [Int32]$a1892622MaxSize = 196608,
+        [Int32]$cis1892622MaxSize = 196608,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892632MaxSize = 32768,
+        [Int32]$cis1892632MaxSize = 32768,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892642MaxSize = 32768,
+        [Int32]$cis1892642MaxSize = 32768,
         [ValidateRange(60000,900000)]
         [Int32]$a189623101MaxIdleTime = 900000,
         [ValidateLength(1,256)]
-        [String]$a2315AccountsRenameadministratoraccount,
+        [String]$cis2315AccountsRenameadministratoraccount,
         [ValidateLength(1,256)]
-        [String]$a2316AccountsRenameguestaccount,
+        [String]$cis2316AccountsRenameguestaccount,
         [ValidateRange(1,30)]
-        [Int32]$a2365MaximumPasswordAge = 30,
+        [Int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,10)]
-        [Int32]$a2373MaxDevicePasswordFailedAttempts = 10,
+        [Int32]$cis2373MaxDevicePasswordFailedAttempts = 10,
         [ValidateRange(1,900)]
-        [Int32]$a2374InactivityTimeoutSecs = 900,
+        [Int32]$cis2374InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
-        [String]$a2375LegalNoticeText,
+        [String]$cis2375LegalNoticeText,
         [ValidateLength(1,512)]
-        [String]$a2376LegalNoticeCaption,
+        [String]$cis2376LegalNoticeCaption,
         [ValidateSet('0','1','2','3','4')]
-        [String]$a2377CachedLogonsCount = '4',
+        [String]$cis2377CachedLogonsCount = '4',
         [ValidateLength(1,15)]
-        [Int32]$a2391AutoDisconnect = 15,
+        [Int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a916LogFileSize = 16384,
+        [Int32]$cis916LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a926LogFileSize = 16384,
+        [Int32]$cis926LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a938LogFileSize = 16384
+        [Int32]$cis938LogFileSize = 16384
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
@@ -70,17 +70,17 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
-    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'a2315AccountsRenameadministratoraccount'){
-        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "a2315AccountsRenameadministratoraccount"'
+    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'cis2315AccountsRenameadministratoraccount'){
+        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "cis2315AccountsRenameadministratoraccount"'
     }
-    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'a2316AccountsRenameguestaccount'){
-        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "a2316AccountsRenameguestaccount"'
+    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
+        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
-    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'a2375LegalNoticeText'){
-        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "a2375LegalNoticeText"'
+    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'cis2375LegalNoticeText'){
+        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "cis2375LegalNoticeText"'
     }
-    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains 'a2376LegalNoticeCaption'){
-        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "a2376LegalNoticeCaption"'
+    if($ExcludeList -notcontains '2.3.7.6' -and $PSBoundParameters.Keys -notcontains 'cis2376LegalNoticeCaption'){
+        throw 'Please add "2.3.7.6" to the ExcludeList or provide a value for "cis2376LegalNoticeCaption"'
     }
 
     if($ExcludeList -notcontains '1.1.1' -and $LevelOne){
@@ -91,13 +91,13 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     }
     if($ExcludeList -notcontains '1.1.2' -and $LevelOne){
         AccountPolicy "1.1.2 - (L1) Ensure Maximum password age is set to 60 or fewer days but not 0" {
-            Maximum_Password_Age = $a112MaximumPasswordAge
+            Maximum_Password_Age = $cis112MaximumPasswordAge
             Name = 'Maximum_Password_Age'
         }
     }
     if($ExcludeList -notcontains '1.1.3' -and $LevelOne){
         AccountPolicy "1.1.3 - (L1) Ensure Minimum password age is set to 1 or more day(s)" {
-            Minimum_Password_Age = $a113MinimumPasswordAge
+            Minimum_Password_Age = $cis113MinimumPasswordAge
             Name = 'Minimum_Password_Age'
         }
     }
@@ -129,20 +129,20 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     }
     if($ExcludeList -notcontains '1.2.1' -and $LevelOne){
         AccountPolicy "1.2.1 - (L1) Ensure Account lockout duration is set to 15 or more minute(s)" {
-            Account_lockout_duration = $a121Accountlockoutduration
+            Account_lockout_duration = $cis121Accountlockoutduration
             Name = 'Account_lockout_duration'
         }
     }
     if($ExcludeList -notcontains '1.2.2' -and $LevelOne){
         AccountPolicy "1.2.2 - (L1) Ensure Account lockout threshold is set to 10 or fewer invalid logon attempt(s) but not 0" {
-            Account_lockout_threshold = $a122Accountlockoutthreshold
+            Account_lockout_threshold = $cis122Accountlockoutthreshold
             Name = 'Account_lockout_threshold'
         }
     }
     if($ExcludeList -notcontains '1.2.3' -and $LevelOne){
         AccountPolicy "1.2.3 - (L1) Ensure Reset account lockout counter after is set to 15 or more minute(s)" {
             Name = 'Reset_account_lockout_counter_after'
-            Reset_account_lockout_counter_after = $a123Resetaccountlockoutcounterafter
+            Reset_account_lockout_counter_after = $cis123Resetaccountlockoutcounterafter
         }
     }
     if($ExcludeList -notcontains '2.2.1' -and $LevelOne){
@@ -448,13 +448,13 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     }
     if($ExcludeList -notcontains '2.3.1.5' -and $LevelOne){
         SecurityOption "2.3.1.5 - (L1) Configure Accounts Rename administrator account" {
-            Accounts_Rename_administrator_account = $a2315AccountsRenameadministratoraccount
+            Accounts_Rename_administrator_account = $cis2315AccountsRenameadministratoraccount
             Name = 'Accounts_Rename_administrator_account'
         }
     }
     if($ExcludeList -notcontains '2.3.1.6' -and $LevelOne){
         SecurityOption "2.3.1.6 - (L1) Configure Accounts Rename guest account" {
-            Accounts_Rename_guest_account = $a2316AccountsRenameguestaccount
+            Accounts_Rename_guest_account = $cis2316AccountsRenameguestaccount
             Name = 'Accounts_Rename_guest_account'
         }
     }
@@ -525,7 +525,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.6.5' -and $LevelOne){
         Registry "2.3.6.5 - (L1) Ensure Domain member Maximum machine account password age is set to 30 or fewer days but not 0" {
             Key = 'HKLM:\System\CurrentControlSet\Services\Netlogon\Parameters'
-            ValueData = $a2365MaximumPasswordAge
+            ValueData = $cis2365MaximumPasswordAge
             ValueName = 'MaximumPasswordAge'
             ValueType = 'Dword'
         }
@@ -557,7 +557,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.7.3' -and $BitLocker){
         Registry "2.3.7.3 - (BL) Ensure Interactive logon Machine account lockout threshold is set to 10 or fewer invalid logon attempts but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2373MaxDevicePasswordFailedAttempts
+            ValueData = $cis2373MaxDevicePasswordFailedAttempts
             ValueName = 'MaxDevicePasswordFailedAttempts'
             ValueType = 'Dword'
         }
@@ -565,7 +565,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.7.4' -and $LevelOne){
         Registry "2.3.7.4 - (L1) Ensure Interactive logon Machine inactivity limit is set to 900 or fewer second(s) but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2374InactivityTimeoutSecs
+            ValueData = $cis2374InactivityTimeoutSecs
             ValueName = 'InactivityTimeoutSecs'
             ValueType = 'Dword'
         }
@@ -573,7 +573,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.7.5' -and $LevelOne){
         Registry "2.3.7.5 - (L1) Configure Interactive logon Message text for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2375LegalNoticeText
+            ValueData = $cis2375LegalNoticeText
             ValueName = 'LegalNoticeText'
             ValueType = 'String'
         }
@@ -581,7 +581,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.7.6' -and $LevelOne){
         Registry "2.3.7.6 - (L1) Configure Interactive logon Message title for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2376LegalNoticeCaption
+            ValueData = $cis2376LegalNoticeCaption
             ValueName = 'LegalNoticeCaption'
             ValueType = 'String'
         }
@@ -589,7 +589,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.7.7' -and $LevelTwo){
         Registry "2.3.7.7 - (L2) Ensure Interactive logon Number of previous logons to cache (in case domain controller is not available) is set to 4 or fewer logon(s)" {
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a2377CachedLogonsCount
+            ValueData = $cis2377CachedLogonsCount
             ValueName = 'CachedLogonsCount'
             ValueType = 'String'
         }
@@ -637,7 +637,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     if($ExcludeList -notcontains '2.3.9.1' -and $LevelOne){
         Registry "2.3.9.1 - (L1) Ensure Microsoft network server Amount of idle time required before suspending session is set to 15 or fewer minute(s)" {
             Key = 'HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters'
-            ValueData = $a2391AutoDisconnect
+            ValueData = $cis2391AutoDisconnect
             ValueName = 'AutoDisconnect'
             ValueType = 'Dword'
         }
@@ -1203,7 +1203,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "9.1.6 - (L1) Ensure Windows Firewall Domain Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging'
-            ValueData = $a916LogFileSize
+            ValueData = $cis916LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1275,7 +1275,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "9.2.6 - (L1) Ensure Windows Firewall Private Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging'
-            ValueData = $a926LogFileSize
+            ValueData = $cis926LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1365,7 +1365,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "9.3.8 - (L1) Ensure Windows Firewall Public Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging'
-            ValueData = $a938LogFileSize
+            ValueData = $cis938LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1779,7 +1779,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.2.5 - (L1) Ensure Password Settings Password Length is set to Enabled 15 or more" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1825PasswordLength
+            ValueData = $cis1825PasswordLength
             ValueName = 'PasswordLength'
             ValueType = 'Dword'
         }
@@ -1788,7 +1788,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.2.6 - (L1) Ensure Password Settings Password Age (Days) is set to Enabled 30 or fewer" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1826PasswordAgeDays
+            ValueData = $cis1826PasswordAgeDays
             ValueName = 'PasswordAgeDays'
             ValueType = 'Dword'
         }
@@ -1932,7 +1932,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.4.10 - (L1) Ensure MSS (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) is set to Enabled 5 or fewer seconds" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a18410ScreenSaverGracePeriod
+            ValueData = $cis18410ScreenSaverGracePeriod
             ValueName = 'ScreenSaverGracePeriod'
             ValueType = 'String'
         }
@@ -1959,7 +1959,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.4.13 - (L1) Ensure MSS (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning is set to Enabled 90 or less" {
             Ensure = 'Present'
             Key = 'HKLM:\SYSTEM\CurrentControlSet\Services\Eventlog\Security'
-            ValueData = $a18413WarningLevel
+            ValueData = $cis18413WarningLevel
             ValueName = 'WarningLevel'
             ValueType = 'Dword'
         }
@@ -3570,7 +3570,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.9.26.1.2 - (L1) Ensure Application Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application'
-            ValueData = $a1892612MaxSize
+            ValueData = $cis1892612MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3588,7 +3588,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.9.26.2.2 - (L1) Ensure Security Specify the maximum log file size (KB) is set to Enabled 196608 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security'
-            ValueData = $a1892622MaxSize
+            ValueData = $cis1892622MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3606,7 +3606,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.9.26.3.2 - (L1) Ensure Setup Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup'
-            ValueData = $a1892632MaxSize
+            ValueData = $cis1892632MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -3624,7 +3624,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.9.26.4.2 - (L1) Ensure System Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\System'
-            ValueData = $a1892642MaxSize
+            ValueData = $cis1892642MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -4642,7 +4642,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.9.102.1.2 - (L1) Ensure Select when Preview Builds and Feature Updates are received is set to Enabled Semi-Annual Channel 180 or more days (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate'
-            ValueData = $a18910212DeferFeatureUpdatesPeriodInDays
+            ValueData = $cis18910212DeferFeatureUpdatesPeriodInDays
             ValueName = 'DeferFeatureUpdatesPeriodInDays'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_2004/CIS_Microsoft_Windows_10_Enterprise_Release_2004.schema.psm1
@@ -12,7 +12,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         [ValidateRange(1,998)]
         [Int32]$cis113MinimumPasswordAge = 1,
         [ValidateRange(14,128)]
-        [Int32]$a114MinimumPasswordLength = 14,
+        [Int32]$cis114MinimumPasswordLength = 14,
         [ValidateRange(15,99999)]
         [Int32]$cis121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
@@ -38,7 +38,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         [ValidateRange(32768,2147483647)]
         [Int32]$cis1892642MaxSize = 32768,
         [ValidateRange(60000,900000)]
-        [Int32]$a189623101MaxIdleTime = 900000,
+        [Int32]$cis189623101MaxIdleTime = 900000,
         [ValidateLength(1,256)]
         [String]$cis2315AccountsRenameadministratoraccount,
         [ValidateLength(1,256)]
@@ -103,7 +103,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
     }
     if($ExcludeList -notcontains '1.1.4' -and $LevelOne){
         AccountPolicy "1.1.4 - (L1) Ensure Minimum password length is set to 14 or more character(s)" {
-            Minimum_Password_Length = $a114MinimumPasswordLength
+            Minimum_Password_Length = $cis114MinimumPasswordLength
             Name = 'Minimum_Password_Length'
         }
     }
@@ -4169,7 +4169,7 @@ Configuration CIS_Microsoft_Windows_10_Enterprise_Release_2004
         Registry "18.9.62.3.10.1 - (L2) Ensure Set time limit for active but idle Remote Desktop Services sessions is set to Enabled 15 minutes or less" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
-            ValueData = $a189623101MaxIdleTime
+            ValueData = $cis189623101MaxIdleTime
             ValueName = 'MaxIdleTime'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.schema.psm1
@@ -21,9 +21,9 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         [ValidateRange(30,365)]
         [int32]$cis1826PasswordAgeDays = 30,
         [ValidateRange(0,90)]
-        [int32]$a18412WarningLevel = 90,
+        [int32]$cis18412WarningLevel = 90,
         [ValidateSet('0','1','2','3','4','5')]
-        [string]$a1849ScreenSaverGracePeriod = '0',
+        [string]$cis1849ScreenSaverGracePeriod = '0',
         [ValidateRange(180,365)]
         [int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
@@ -43,13 +43,13 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         [ValidateRange(1,30)]
         [int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,900)]
-        [int32]$a2373InactivityTimeoutSecs = 900,
+        [int32]$cis2373InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
-        [string]$a2374LegalNoticeText,
+        [string]$cis2374LegalNoticeText,
         [ValidateLength(1,512)]
-        [string]$a2375LegalNoticeCaption,
+        [string]$cis2375LegalNoticeCaption,
         [ValidateSet('0','1','2','3','4')]
-        [string]$a2376CachedLogonsCount = '4',
+        [string]$cis2376CachedLogonsCount = '4',
         [ValidateLength(1,15)]
         [int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
@@ -71,11 +71,11 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
         throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
-    if($ExcludeList -notcontains '2.3.7.4' -and $PSBoundParameters.Keys -notcontains 'a2374LegalNoticeText'){
-        throw 'Please add "2.3.7.4" to the ExcludeList or provide a value for "a2374LegalNoticeText"'
+    if($ExcludeList -notcontains '2.3.7.4' -and $PSBoundParameters.Keys -notcontains 'cis2374LegalNoticeText'){
+        throw 'Please add "2.3.7.4" to the ExcludeList or provide a value for "cis2374LegalNoticeText"'
     }
-    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'a2375LegalNoticeCaption'){
-        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "a2375LegalNoticeCaption"'
+    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'cis2375LegalNoticeCaption'){
+        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "cis2375LegalNoticeCaption"'
     }
 
     if($ExcludeList -notcontains '1.1.1' -and $LevelOne){
@@ -530,7 +530,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.7.3' -and $LevelOne){
         Registry "2.3.7.3 - (L1) Ensure Interactive logon Machine inactivity limit is set to 900 or fewer second(s) but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2373InactivityTimeoutSecs
+            ValueData = $cis2373InactivityTimeoutSecs
             ValueName = 'InactivityTimeoutSecs'
             ValueType = 'Dword'
         }
@@ -538,7 +538,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.7.4' -and $LevelOne){
         Registry "2.3.7.4 - (L1) Configure Interactive logon Message text for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2374LegalNoticeText
+            ValueData = $cis2374LegalNoticeText
             ValueName = 'LegalNoticeText'
             ValueType = 'String'
         }
@@ -546,7 +546,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.7.5' -and $LevelOne){
         Registry "2.3.7.5 - (L1) Configure Interactive logon Message title for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2375LegalNoticeCaption
+            ValueData = $cis2375LegalNoticeCaption
             ValueName = 'LegalNoticeCaption'
             ValueType = 'String'
         }
@@ -554,7 +554,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.7.6' -and $LevelTwo){
         Registry "2.3.7.6 - (L2) Ensure Interactive logon Number of previous logons to cache (in case domain controller is not available) is set to 4 or fewer logon(s) (MS only)" {
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a2376CachedLogonsCount
+            ValueData = $cis2376CachedLogonsCount
             ValueName = 'CachedLogonsCount'
             ValueType = 'String'
         }
@@ -1676,7 +1676,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.4.9 - (L1) Ensure MSS (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) is set to Enabled 5 or fewer seconds" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a1849ScreenSaverGracePeriod
+            ValueData = $cis1849ScreenSaverGracePeriod
             ValueName = 'ScreenSaverGracePeriod'
             ValueType = 'String'
         }
@@ -1703,7 +1703,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.4.12 - (L1) Ensure MSS (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning is set to Enabled 90 or less" {
             Ensure = 'Present'
             Key = 'HKLM:\SYSTEM\CurrentControlSet\Services\Eventlog\Security'
-            ValueData = $a18412WarningLevel
+            ValueData = $cis18412WarningLevel
             ValueName = 'WarningLevel'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.schema.psm1
@@ -7,41 +7,41 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         [boolean]$LevelTwo = $false,
         [boolean]$NextGenerationWindowsSecurity = $false,
         [ValidateRange(60,999)]
-        [Int32]$a112MaximumPasswordAge = 60,
+        [Int32]$cis112MaximumPasswordAge = 60,
         [ValidateRange(1,998)]
-        [Int32]$a113MinimumPasswordAge = 1,
+        [Int32]$cis113MinimumPasswordAge = 1,
         [ValidateRange(15,99999)]
-        [Int32]$a121Accountlockoutduration = 15,
+        [Int32]$cis121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
-        [Int32]$a122Accountlockoutthreshold = 10,
+        [Int32]$cis122Accountlockoutthreshold = 10,
         [ValidateRange(15,99999)]
-        [Int32]$a123Resetaccountlockoutcounterafter = 15,
+        [Int32]$cis123Resetaccountlockoutcounterafter = 15,
         [ValidateRange(15,64)]
-        [int32]$a1825PasswordLength = 15,
+        [int32]$cis1825PasswordLength = 15,
         [ValidateRange(30,365)]
-        [int32]$a1826PasswordAgeDays = 30,
+        [int32]$cis1826PasswordAgeDays = 30,
         [ValidateRange(0,90)]
         [int32]$a18412WarningLevel = 90,
         [ValidateSet('0','1','2','3','4','5')]
         [string]$a1849ScreenSaverGracePeriod = '0',
         [ValidateRange(180,365)]
-        [int32]$a18910212DeferFeatureUpdatesPeriodInDays = 180,
+        [int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
-        [int32]$a1892612MaxSize = 32768,
+        [int32]$cis1892612MaxSize = 32768,
         [ValidateRange(196608,2147483647)]
-        [int32]$a1892622MaxSize = 196608,
+        [int32]$cis1892622MaxSize = 196608,
         [ValidateRange(32768,2147483647)]
-        [int32]$a1892632MaxSize = 32768,
+        [int32]$cis1892632MaxSize = 32768,
         [ValidateRange(32768,2147483647)]
-        [int32]$a1892642MaxSize = 32768,
+        [int32]$cis1892642MaxSize = 32768,
         [ValidateRange(60000,900000)]
-        [int32]$a189593101MaxIdleTime = 900000,
+        [int32]$cis189593101MaxIdleTime = 900000,
         [ValidateLength(1,256)]
-        [String]$a2315AccountsRenameadministratoraccount,
+        [String]$cis2315AccountsRenameadministratoraccount,
         [ValidateLength(1,256)]
-        [String]$a2316AccountsRenameguestaccount,
+        [String]$cis2316AccountsRenameguestaccount,
         [ValidateRange(1,30)]
-        [int32]$a2365MaximumPasswordAge = 30,
+        [int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,900)]
         [int32]$a2373InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
@@ -51,13 +51,13 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         [ValidateSet('0','1','2','3','4')]
         [string]$a2376CachedLogonsCount = '4',
         [ValidateLength(1,15)]
-        [int32]$a2391AutoDisconnect = 15,
+        [int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
-        [int32]$a916LogFileSize = 16384,
+        [int32]$cis916LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [int32]$a926LogFileSize = 16384,
+        [int32]$cis926LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [int32]$a938LogFileSize = 16384
+        [int32]$cis938LogFileSize = 16384
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
@@ -65,11 +65,11 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
-    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'a2315AccountsRenameadministratoraccount'){
-        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "a2315AccountsRenameadministratoraccount"'
+    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'cis2315AccountsRenameadministratoraccount'){
+        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "cis2315AccountsRenameadministratoraccount"'
     }
-    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'a2316AccountsRenameguestaccount'){
-        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "a2316AccountsRenameguestaccount"'
+    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
+        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
     if($ExcludeList -notcontains '2.3.7.4' -and $PSBoundParameters.Keys -notcontains 'a2374LegalNoticeText'){
         throw 'Please add "2.3.7.4" to the ExcludeList or provide a value for "a2374LegalNoticeText"'
@@ -86,13 +86,13 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     }
     if($ExcludeList -notcontains '1.1.2' -and $LevelOne){
         AccountPolicy "1.1.2 - (L1) Ensure Maximum password age is set to 60 or fewer days but not 0" {
-            Maximum_Password_Age = $a112MaximumPasswordAge
+            Maximum_Password_Age = $cis112MaximumPasswordAge
             Name = 'Maximum_Password_Age'
         }
     }
     if($ExcludeList -notcontains '1.1.3' -and $LevelOne){
         AccountPolicy "1.1.3 - (L1) Ensure Minimum password age is set to 1 or more day(s)" {
-            Minimum_Password_Age = $a113MinimumPasswordAge
+            Minimum_Password_Age = $cis113MinimumPasswordAge
             Name = 'Minimum_Password_Age'
         }
     }
@@ -116,20 +116,20 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     }
     if($ExcludeList -notcontains '1.2.1' -and $LevelOne){
         AccountPolicy "1.2.1 - (L1) Ensure Account lockout duration is set to 15 or more minute(s)" {
-            Account_lockout_duration = $a121Accountlockoutduration
+            Account_lockout_duration = $cis121Accountlockoutduration
             Name = 'Account_lockout_duration'
         }
     }
     if($ExcludeList -notcontains '1.2.2' -and $LevelOne){
         AccountPolicy "1.2.2 - (L1) Ensure Account lockout threshold is set to 10 or fewer invalid logon attempt(s) but not 0" {
-            Account_lockout_threshold = $a122Accountlockoutthreshold
+            Account_lockout_threshold = $cis122Accountlockoutthreshold
             Name = 'Account_lockout_threshold'
         }
     }
     if($ExcludeList -notcontains '1.2.3' -and $LevelOne){
         AccountPolicy "1.2.3 - (L1) Ensure Reset account lockout counter after is set to 15 or more minute(s)" {
             Name = 'Reset_account_lockout_counter_after'
-            Reset_account_lockout_counter_after = $a123Resetaccountlockoutcounterafter
+            Reset_account_lockout_counter_after = $cis123Resetaccountlockoutcounterafter
         }
     }
     if($ExcludeList -notcontains '2.2.1' -and $LevelOne){
@@ -421,13 +421,13 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     }
     if($ExcludeList -notcontains '2.3.1.5' -and $LevelOne){
         SecurityOption "2.3.1.5 - (L1) Configure Accounts Rename administrator account" {
-            Accounts_Rename_administrator_account = $a2315AccountsRenameadministratoraccount
+            Accounts_Rename_administrator_account = $cis2315AccountsRenameadministratoraccount
             Name = 'Accounts_Rename_administrator_account'
         }
     }
     if($ExcludeList -notcontains '2.3.1.6' -and $LevelOne){
         SecurityOption "2.3.1.6 - (L1) Configure Accounts Rename guest account" {
-            Accounts_Rename_guest_account = $a2316AccountsRenameguestaccount
+            Accounts_Rename_guest_account = $cis2316AccountsRenameguestaccount
             Name = 'Accounts_Rename_guest_account'
         }
     }
@@ -498,7 +498,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.6.5' -and $LevelOne){
         Registry "2.3.6.5 - (L1) Ensure Domain member Maximum machine account password age is set to 30 or fewer days but not 0" {
             Key = 'HKLM:\System\CurrentControlSet\Services\Netlogon\Parameters'
-            ValueData = $a2365MaximumPasswordAge
+            ValueData = $cis2365MaximumPasswordAge
             ValueName = 'MaximumPasswordAge'
             ValueType = 'Dword'
         }
@@ -610,7 +610,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
     if($ExcludeList -notcontains '2.3.9.1' -and $LevelOne){
         Registry "2.3.9.1 - (L1) Ensure Microsoft network server Amount of idle time required before suspending session is set to 15 or fewer minute(s)" {
             Key = 'HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters'
-            ValueData = $a2391AutoDisconnect
+            ValueData = $cis2391AutoDisconnect
             ValueName = 'AutoDisconnect'
             ValueType = 'Dword'
         }
@@ -956,7 +956,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "9.1.6 - (L1) Ensure Windows Firewall Domain Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging'
-            ValueData = $a916LogFileSize
+            ValueData = $cis916LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1028,7 +1028,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "9.2.6 - (L1) Ensure Windows Firewall Private Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging'
-            ValueData = $a926LogFileSize
+            ValueData = $cis926LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1118,7 +1118,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "9.3.8 - (L1) Ensure Windows Firewall Public Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging'
-            ValueData = $a938LogFileSize
+            ValueData = $cis938LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1532,7 +1532,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.2.5 - (L1) Ensure Password Settings Password Length is set to Enabled 15 or more (MS only)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1825PasswordLength
+            ValueData = $cis1825PasswordLength
             ValueName = 'PasswordLength'
             ValueType = 'Dword'
         }
@@ -1541,7 +1541,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.2.6 - (L1) Ensure Password Settings Password Age (Days) is set to Enabled 30 or fewer (MS only)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1826PasswordAgeDays
+            ValueData = $cis1826PasswordAgeDays
             ValueName = 'PasswordAgeDays'
             ValueType = 'Dword'
         }
@@ -2570,7 +2570,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.9.26.1.2 - (L1) Ensure Application Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Application'
-            ValueData = $a1892612MaxSize
+            ValueData = $cis1892612MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2588,7 +2588,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.9.26.2.2 - (L1) Ensure Security Specify the maximum log file size (KB) is set to Enabled 196608 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Security'
-            ValueData = $a1892622MaxSize
+            ValueData = $cis1892622MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2606,7 +2606,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.9.26.3.2 - (L1) Ensure Setup Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\Setup'
-            ValueData = $a1892632MaxSize
+            ValueData = $cis1892632MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2624,7 +2624,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.9.26.4.2 - (L1) Ensure System Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\EventLog\System'
-            ValueData = $a1892642MaxSize
+            ValueData = $cis1892642MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2795,7 +2795,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.9.59.3.10.1 - (L2) Ensure Set time limit for active but idle Remote Desktop Services sessions is set to Enabled 15 minutes or less" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
-            ValueData = $a189593101MaxIdleTime
+            ValueData = $cis189593101MaxIdleTime
             ValueName = 'MaxIdleTime'
             ValueType = 'Dword'
         }
@@ -3250,7 +3250,7 @@ Configuration CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
         Registry "18.9.102.1.2 - (L1) Ensure Select when Preview Builds and Feature Updates are received is set to Enabled Semi-Annual Channel 180 or more days (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate'
-            ValueData = $a18910212DeferFeatureUpdatesPeriodInDays
+            ValueData = $cis18910212DeferFeatureUpdatesPeriodInDays
             ValueName = 'DeferFeatureUpdatesPeriodInDays'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.schema.psm1
@@ -21,9 +21,9 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         [ValidateRange(30,365)]
         [Int32]$cis1826PasswordAgeDays = 30,
         [ValidateRange(0,90)]
-        [Int32]$a18412WarningLevel = 90,
+        [Int32]$cis18412WarningLevel = 90,
         [ValidateSet('0','1','2','3','4','5')]
-        [String]$a1849ScreenSaverGracePeriod = '0',
+        [String]$cis1849ScreenSaverGracePeriod = '0',
         [ValidateRange(180,365)]
         [Int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
@@ -43,13 +43,13 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         [ValidateRange(1,30)]
         [Int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,900)]
-        [Int32]$a2373InactivityTimeoutSecs = 900,
+        [Int32]$cis2373InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
-        [String]$a2374LegalNoticeText,
+        [String]$cis2374LegalNoticeText,
         [ValidateLength(1,512)]
-        [String]$a2375LegalNoticeCaption,
+        [String]$cis2375LegalNoticeCaption,
         [ValidateSet('0','1','2','3','4')]
-        [String]$a2376CachedLogonsCount = '4',
+        [String]$cis2376CachedLogonsCount = '4',
         [ValidateLength(1,15)]
         [Int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
@@ -71,11 +71,11 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
         throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
-    if($ExcludeList -notcontains '2.3.7.4' -and $PSBoundParameters.Keys -notcontains 'a2374LegalNoticeText'){
-        throw 'Please add "2.3.7.4" to the ExcludeList or provide a value for "a2374LegalNoticeText"'
+    if($ExcludeList -notcontains '2.3.7.4' -and $PSBoundParameters.Keys -notcontains 'cis2374LegalNoticeText'){
+        throw 'Please add "2.3.7.4" to the ExcludeList or provide a value for "cis2374LegalNoticeText"'
     }
-    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'a2375LegalNoticeCaption'){
-        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "a2375LegalNoticeCaption"'
+    if($ExcludeList -notcontains '2.3.7.5' -and $PSBoundParameters.Keys -notcontains 'cis2375LegalNoticeCaption'){
+        throw 'Please add "2.3.7.5" to the ExcludeList or provide a value for "cis2375LegalNoticeCaption"'
     }
 
     if($ExcludeList -notcontains '1.1.1' -and $LevelOne){
@@ -530,7 +530,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.7.3' -and $LevelOne){
         Registry "2.3.7.3 - (L1) Ensure Interactive logon Machine inactivity limit is set to 900 or fewer second(s) but not 0" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2373InactivityTimeoutSecs
+            ValueData = $cis2373InactivityTimeoutSecs
             ValueName = 'InactivityTimeoutSecs'
             ValueType = 'Dword'
         }
@@ -538,7 +538,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.7.4' -and $LevelOne){
         Registry "2.3.7.4 - (L1) Configure Interactive logon Message text for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2374LegalNoticeText
+            ValueData = $cis2374LegalNoticeText
             ValueName = 'LegalNoticeText'
             ValueType = 'String'
         }
@@ -546,7 +546,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.7.5' -and $LevelOne){
         Registry "2.3.7.5 - (L1) Configure Interactive logon Message title for users attempting to log on" {
             Key = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System'
-            ValueData = $a2375LegalNoticeCaption
+            ValueData = $cis2375LegalNoticeCaption
             ValueName = 'LegalNoticeCaption'
             ValueType = 'String'
         }
@@ -554,7 +554,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.7.6' -and $LevelTwo){
         Registry "2.3.7.6 - (L2) Ensure Interactive logon Number of previous logons to cache (in case domain controller is not available) is set to 4 or fewer logon(s) (MS only)" {
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a2376CachedLogonsCount
+            ValueData = $cis2376CachedLogonsCount
             ValueName = 'CachedLogonsCount'
             ValueType = 'String'
         }
@@ -1676,7 +1676,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.4.9 - (L1) Ensure MSS (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended) is set to Enabled 5 or fewer seconds" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon'
-            ValueData = $a1849ScreenSaverGracePeriod
+            ValueData = $cis1849ScreenSaverGracePeriod
             ValueName = 'ScreenSaverGracePeriod'
             ValueType = 'String'
         }
@@ -1703,7 +1703,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.4.12 - (L1) Ensure MSS (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning is set to Enabled 90 or less" {
             Ensure = 'Present'
             Key = 'HKLM:\SYSTEM\CurrentControlSet\Services\Eventlog\Security'
-            ValueData = $a18412WarningLevel
+            ValueData = $cis18412WarningLevel
             ValueName = 'WarningLevel'
             ValueType = 'Dword'
         }

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.schema.psm1
@@ -7,41 +7,41 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         [Boolean]$LevelTwo = $false,
         [Boolean]$NextGenerationWindowsSecurity = $false,
         [ValidateRange(60,999)]
-        [Int32]$a112MaximumPasswordAge = 60,
+        [Int32]$cis112MaximumPasswordAge = 60,
         [ValidateRange(1,998)]
-        [Int32]$a113MinimumPasswordAge = 30,
+        [Int32]$cis113MinimumPasswordAge = 30,
         [ValidateRange(15,99999)]
-        [Int32]$a121Accountlockoutduration = 15,
+        [Int32]$cis121Accountlockoutduration = 15,
         [ValidateRange(10,999)]
-        [Int32]$a122Accountlockoutthreshold = 10,
+        [Int32]$cis122Accountlockoutthreshold = 10,
         [ValidateRange(15,99999)]
-        [Int32]$a123Resetaccountlockoutcounterafter = 15,
+        [Int32]$cis123Resetaccountlockoutcounterafter = 15,
         [ValidateRange(15,64)]
-        [Int32]$a1825PasswordLength = 15,
+        [Int32]$cis1825PasswordLength = 15,
         [ValidateRange(30,365)]
-        [Int32]$a1826PasswordAgeDays = 30,
+        [Int32]$cis1826PasswordAgeDays = 30,
         [ValidateRange(0,90)]
         [Int32]$a18412WarningLevel = 90,
         [ValidateSet('0','1','2','3','4','5')]
         [String]$a1849ScreenSaverGracePeriod = '0',
         [ValidateRange(180,365)]
-        [Int32]$a18910212DeferFeatureUpdatesPeriodInDays = 180,
+        [Int32]$cis18910212DeferFeatureUpdatesPeriodInDays = 180,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892612MaxSize = 32768,
+        [Int32]$cis1892612MaxSize = 32768,
         [ValidateRange(196608,2147483647)]
-        [Int32]$a1892622MaxSize = 196608,
+        [Int32]$cis1892622MaxSize = 196608,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892632MaxSize = 32768,
+        [Int32]$cis1892632MaxSize = 32768,
         [ValidateRange(32768,2147483647)]
-        [Int32]$a1892642MaxSize = 32768,
+        [Int32]$cis1892642MaxSize = 32768,
         [ValidateRange(60000,900000)]
-        [Int32]$a189593101MaxIdleTime = 900000,
+        [Int32]$cis189593101MaxIdleTime = 900000,
         [ValidateLength(1,256)]
-        [String]$a2315AccountsRenameadministratoraccount,
+        [String]$cis2315AccountsRenameadministratoraccount,
         [ValidateLength(1,256)]
-        [String]$a2316AccountsRenameguestaccount,
+        [String]$cis2316AccountsRenameguestaccount,
         [ValidateRange(1,30)]
-        [Int32]$a2365MaximumPasswordAge = 30,
+        [Int32]$cis2365MaximumPasswordAge = 30,
         [ValidateRange(1,900)]
         [Int32]$a2373InactivityTimeoutSecs = 900,
         [ValidateLength(1,2048)]
@@ -51,13 +51,13 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         [ValidateSet('0','1','2','3','4')]
         [String]$a2376CachedLogonsCount = '4',
         [ValidateLength(1,15)]
-        [Int32]$a2391AutoDisconnect = 15,
+        [Int32]$cis2391AutoDisconnect = 15,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a916LogFileSize = 16384,
+        [Int32]$cis916LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a926LogFileSize = 16384,
+        [Int32]$cis926LogFileSize = 16384,
         [ValidateRange(16384,2147483647)]
-        [Int32]$a938LogFileSize = 16384
+        [Int32]$cis938LogFileSize = 16384
     )
 
     Import-DSCResource -ModuleName 'PSDesiredStateConfiguration'
@@ -65,11 +65,11 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     Import-DSCResource -ModuleName 'AuditPolicyDSC' -ModuleVersion '1.4.0.0'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC' -ModuleVersion '2.10.0.0'
 
-    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'a2315AccountsRenameadministratoraccount'){
-        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "a2315AccountsRenameadministratoraccount"'
+    if($ExcludeList -notcontains '2.3.1.5' -and $PSBoundParameters.Keys -notcontains 'cis2315AccountsRenameadministratoraccount'){
+        throw 'Please add "2.3.1.5" to the ExcludeList or provide a value for "cis2315AccountsRenameadministratoraccount"'
     }
-    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'a2316AccountsRenameguestaccount'){
-        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "a2316AccountsRenameguestaccount"'
+    if($ExcludeList -notcontains '2.3.1.6' -and $PSBoundParameters.Keys -notcontains 'cis2316AccountsRenameguestaccount'){
+        throw 'Please add "2.3.1.6" to the ExcludeList or provide a value for "cis2316AccountsRenameguestaccount"'
     }
     if($ExcludeList -notcontains '2.3.7.4' -and $PSBoundParameters.Keys -notcontains 'a2374LegalNoticeText'){
         throw 'Please add "2.3.7.4" to the ExcludeList or provide a value for "a2374LegalNoticeText"'
@@ -86,13 +86,13 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     }
     if($ExcludeList -notcontains '1.1.2' -and $LevelOne){
         AccountPolicy "1.1.2 - (L1) Ensure Maximum password age is set to 60 or fewer days but not 0" {
-            Maximum_Password_Age = $a112MaximumPasswordAge
+            Maximum_Password_Age = $cis112MaximumPasswordAge
             Name = 'Maximum_Password_Age'
         }
     }
     if($ExcludeList -notcontains '1.1.3' -and $LevelOne){
         AccountPolicy "1.1.3 - (L1) Ensure Minimum password age is set to 1 or more day(s)" {
-            Minimum_Password_Age = $a113MinimumPasswordAge
+            Minimum_Password_Age = $cis113MinimumPasswordAge
             Name = 'Minimum_Password_Age'
         }
     }
@@ -116,20 +116,20 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     }
     if($ExcludeList -notcontains '1.2.1' -and $LevelOne){
         AccountPolicy "1.2.1 - (L1) Ensure Account lockout duration is set to 15 or more minute(s)" {
-            Account_lockout_duration = $a121Accountlockoutduration
+            Account_lockout_duration = $cis121Accountlockoutduration
             Name = 'Account_lockout_duration'
         }
     }
     if($ExcludeList -notcontains '1.2.2' -and $LevelOne){
         AccountPolicy "1.2.2 - (L1) Ensure Account lockout threshold is set to 10 or fewer invalid logon attempt(s) but not 0" {
-            Account_lockout_threshold = $a122Accountlockoutthreshold
+            Account_lockout_threshold = $cis122Accountlockoutthreshold
             Name = 'Account_lockout_threshold'
         }
     }
     if($ExcludeList -notcontains '1.2.3' -and $LevelOne){
         AccountPolicy "1.2.3 - (L1) Ensure Reset account lockout counter after is set to 15 or more minute(s)" {
             Name = 'Reset_account_lockout_counter_after'
-            Reset_account_lockout_counter_after = $a123Resetaccountlockoutcounterafter
+            Reset_account_lockout_counter_after = $cis123Resetaccountlockoutcounterafter
         }
     }
     if($ExcludeList -notcontains '2.2.1' -and $LevelOne){
@@ -421,13 +421,13 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     }
     if($ExcludeList -notcontains '2.3.1.5' -and $LevelOne){
         SecurityOption "2.3.1.5 - (L1) Configure Accounts Rename administrator account" {
-            Accounts_Rename_administrator_account = $a2315AccountsRenameadministratoraccount
+            Accounts_Rename_administrator_account = $cis2315AccountsRenameadministratoraccount
             Name = 'Accounts_Rename_administrator_account'
         }
     }
     if($ExcludeList -notcontains '2.3.1.6' -and $LevelOne){
         SecurityOption "2.3.1.6 - (L1) Configure Accounts Rename guest account" {
-            Accounts_Rename_guest_account = $a2316AccountsRenameguestaccount
+            Accounts_Rename_guest_account = $cis2316AccountsRenameguestaccount
             Name = 'Accounts_Rename_guest_account'
         }
     }
@@ -498,7 +498,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.6.5' -and $LevelOne){
         Registry "2.3.6.5 - (L1) Ensure Domain member Maximum machine account password age is set to 30 or fewer days but not 0" {
             Key = 'HKLM:\System\CurrentControlSet\Services\Netlogon\Parameters'
-            ValueData = $a2365MaximumPasswordAge
+            ValueData = $cis2365MaximumPasswordAge
             ValueName = 'MaximumPasswordAge'
             ValueType = 'Dword'
         }
@@ -610,7 +610,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
     if($ExcludeList -notcontains '2.3.9.1' -and $LevelOne){
         Registry "2.3.9.1 - (L1) Ensure Microsoft network server Amount of idle time required before suspending session is set to 15 or fewer minute(s)" {
             Key = 'HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters'
-            ValueData = $a2391AutoDisconnect
+            ValueData = $cis2391AutoDisconnect
             ValueName = 'AutoDisconnect'
             ValueType = 'Dword'
         }
@@ -956,7 +956,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "9.1.6 - (L1) Ensure Windows Firewall Domain Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging'
-            ValueData = $a916LogFileSize
+            ValueData = $cis916LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1028,7 +1028,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "9.2.6 - (L1) Ensure Windows Firewall Private Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging'
-            ValueData = $a926LogFileSize
+            ValueData = $cis926LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1118,7 +1118,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "9.3.8 - (L1) Ensure Windows Firewall Public Logging Size limit (KB) is set to 16384 KB or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging'
-            ValueData = $a938LogFileSize
+            ValueData = $cis938LogFileSize
             ValueName = 'LogFileSize'
             ValueType = 'Dword'
         }
@@ -1532,7 +1532,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.2.5 - (L1) Ensure Password Settings Password Length is set to Enabled 15 or more (MS only)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1825PasswordLength
+            ValueData = $cis1825PasswordLength
             ValueName = 'PasswordLength'
             ValueType = 'Dword'
         }
@@ -1541,7 +1541,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.2.6 - (L1) Ensure Password Settings Password Age (Days) is set to Enabled 30 or fewer (MS only)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft Services\AdmPwd'
-            ValueData = $a1826PasswordAgeDays
+            ValueData = $cis1826PasswordAgeDays
             ValueName = 'PasswordAgeDays'
             ValueType = 'Dword'
         }
@@ -2597,7 +2597,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.9.26.1.2 - (L1) Ensure Application Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\Application'
-            ValueData = $a1892612MaxSize
+            ValueData = $cis1892612MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2615,7 +2615,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.9.26.2.2 - (L1) Ensure Security Specify the maximum log file size (KB) is set to Enabled 196608 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\Security'
-            ValueData = $a1892622MaxSize
+            ValueData = $cis1892622MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2633,7 +2633,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.9.26.3.2 - (L1) Ensure Setup Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\Setup'
-            ValueData = $a1892632MaxSize
+            ValueData = $cis1892632MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2651,7 +2651,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.9.26.4.2 - (L1) Ensure System Specify the maximum log file size (KB) is set to Enabled 32768 or greater" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\EventLog\System'
-            ValueData = $a1892642MaxSize
+            ValueData = $cis1892642MaxSize
             ValueName = 'MaxSize'
             ValueType = 'Dword'
         }
@@ -2822,7 +2822,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.9.59.3.10.1 - (L2) Ensure Set time limit for active but idle Remote Desktop Services sessions is set to Enabled 15 minutes or less" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
-            ValueData = $a189593101MaxIdleTime
+            ValueData = $cis189593101MaxIdleTime
             ValueName = 'MaxIdleTime'
             ValueType = 'Dword'
         }
@@ -3365,7 +3365,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
         Registry "18.9.102.1.2 - (L1) Ensure Select when Preview Builds and Feature Updates are received is set to Enabled Semi-Annual Channel 180 or more days (3)" {
             Ensure = 'Present'
             Key = 'HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate'
-            ValueData = $a18910212DeferFeatureUpdatesPeriodInDays
+            ValueData = $cis18910212DeferFeatureUpdatesPeriodInDays
             ValueName = 'DeferFeatureUpdatesPeriodInDays'
             ValueType = 'Dword'
         }


### PR DESCRIPTION
- Take 2 on #169 changed the "a" to a "cis" per @edthedev  suggestion
- This will require a new version number because the gallery will remember a version number forever and 2.1 was taken up by the bad release.