### PR TITLE
Issue175

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 2.2.7
+### Added
+### Changed
+- UserRightsAssignment's 'Identities' property will now be sorted so that SIDs will be consistently ordered between resources. [Issue 175](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/175)
+### Removed
+
 ## 2.2.6
 ### Added
 ### Changed

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSCResourceGeneration.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.6'
+ModuleVersion = '2.2.7'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSCResourceGeneration/functions/private/ConvertFrom-PrivilegeRightRawGPO.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/ConvertFrom-PrivilegeRightRawGPO.ps1
@@ -17,7 +17,8 @@ function ConvertFrom-PrivilegeRightRawGPO {
     process {
         $privilegeHash = @{
             'Policy' = $script:UserRights[$Policy]
-            'Identity' = ($Identity -split ',')
+            # The sort-object ensures consistent ordering of SIDs for the same settings accross resources to make comparisons easier.
+            'Identity' = ($Identity -split ',') | Sort-Object
             'Force' = '$true'
             'ResourceType' = 'UserRightsAssignment'
         }


### PR DESCRIPTION
Solution for #175 
- UserRightsAssignment's 'Identities' property will now be sorted so that SIDs will be consistently ordered between resources. [Issue 175](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/175)