### PR TITLE
PowerShell 7 support - Issue128

### DIFF
--- a/.github/workflows/pester_CISDSC.yml
+++ b/.github/workflows/pester_CISDSC.yml
@@ -3,24 +3,26 @@ name: CISDSC Pester Tests
 on:
   pull_request:
     branches:
-    - main
+      - main
     paths:
-    - 'src/CISDSC/CISDSC.psm1'
-    - 'test/CISDSC.Tests.ps1'
+      - "src/CISDSC/CISDSC.psm1"
+      - "test/CISDSC.Tests.ps1"
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: tools\install_dependencies.ps1
-      shell: powershell
-    - name: Run tests PowerShell 5
-      run: Invoke-Pester -Path '.\test\CISDSC.Tests.ps1' -CI -Output Detailed
-      shell: powershell
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: tools\install_dependencies.ps1
+        shell: powershell
+      - name: Run tests PowerShell 5
+        run: Invoke-Pester -Path '.\test\CISDSC.Tests.ps1' -CI -Output Detailed
+        shell: powershell
+      - name: Run tests PowerShell 7
+        run: Invoke-Pester -Path '.\test\CISDSC.Tests.ps1' -CI -Output Detailed
+        shell: pwsh

--- a/.github/workflows/pester_CISDSCResourceGeneration.yml
+++ b/.github/workflows/pester_CISDSCResourceGeneration.yml
@@ -3,25 +3,24 @@ name: CISDSCResourceGeneration Pester Tests
 on:
   pull_request:
     branches:
-    - main
+      - main
     paths:
-    - 'src/CISDSCResourceGeneration/**'
-    - 'test/**'
-    - '!test/CISDSC.Tests.ps1'
+      - "src/CISDSCResourceGeneration/**"
+      - "test/**"
+      - "!test/CISDSC.Tests.ps1"
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: tools\install_dependencies.ps1
-      shell: powershell
-    - name: Run tests PowerShell 5
-      run: Invoke-Pester -Path '.\test\CISDSCResourceGeneration.Tests.ps1' -CI -Output Detailed
-      shell: powershell
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: tools\install_dependencies.ps1
+        shell: pwsh
+      - name: Run tests PowerShell 7
+        run: Invoke-Pester -Path '.\test\CISDSCResourceGeneration.Tests.ps1' -CI -Output Detailed
+        shell: pwsh

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
 
     // Start PowerShell
     "windows": {
-        "command": "${SystemRoot}/system32/WindowsPowerShell/v1.0/powershell.exe",
+        "command": "${SystemRoot}/Program Files/PowerShell/7/pwsh.exe",
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {

--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 2.3.0
+### Changed
+- Updated the module to work with the latest release of GPRegistryPolicyParser and increased the minimum version to 7.
+- Resolved the unapproved verb warning at import this was fixed along side PS 7 support in the latest version of GPRegistryPolicyParser.
+
 ## 2.2.9
 ### Changed
 - Converted expected warning messages to debug within Import-GptTmpl and Import-RegistryPol per [Issue 182](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/182)

--- a/docs/new_resources.md
+++ b/docs/new_resources.md
@@ -26,7 +26,7 @@ Configuration MyWorkstation
 # How do I create new ones?
 1) Acquire the GPOs and Excel documentation from [CIS](./static_corrections.md).
 
-2) Set up your development environment with the following PowerShell. This will clone this repository and install the dependencies specified in [install_dependencies](/tools/install_dependencies.ps1). Due to the dependency on [GPRegistryPolicyParser](https://www.powershellgallery.com/packages/GPRegistryPolicyParser) you will need to do this in Windows PowerShell 5.1.
+2) Set up your development environment with the following PowerShell. This will clone this repository and install the dependencies specified in [install_dependencies](/tools/install_dependencies.ps1).
 ```powershell
 git clone https://github.com/techservicesillinois/SecOps-Powershell-CISDSC
 Set-Location -Path '.\SecOps-Powershell-CISDSC'

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'CISDSCResourceGeneration.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.2.9'
+    ModuleVersion     = '2.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -25,7 +25,7 @@
     Description       = 'Used to generate DSC composite resources for CISDSC'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.0'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''

--- a/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
@@ -4,13 +4,13 @@
    These are settings defined by admx templates that result in registry settings. They differ from a GptTmpl.inf registry values
    because they are not explictly configured within group policy as registry keys.
 
-   This function relies on the GPRegistryPolicyParser module by MicroSoft.
+   This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
 .DESCRIPTION
    Recursively finds all 'registry.pol' files in the provided directory that contain abstracted registry settings.
    These are settings defined by admx templates that result in registry settings. They differ from a GptTmpl.inf registry values
    because they are not explictly configured within group policy as registry keys.
 
-   This function relies on the GPRegistryPolicyParser module by MicroSoft.
+   This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
 .PARAMETER GPOPath
     Path to the GPO files (build kit) from CIS containing the benchmarks settings.
 .EXAMPLE
@@ -29,7 +29,7 @@ function Import-RegistryPol {
     process {
         Get-ChildItem -Path $GPOPath -Filter 'registry.pol' -Recurse | ForEach-Object -Process {
             Write-Verbose -Message "Importing $($_.FullName)"
-            $PolicyData = Parse-PolFile -Path $_.FullName
+            $PolicyData = Read-PolFile -Path $_.FullName
 
             Foreach ($Policy in $PolicyData) {
                 switch ($_.Directory.BaseName) {

--- a/tools/install_dependencies.ps1
+++ b/tools/install_dependencies.ps1
@@ -1,3 +1,4 @@
-Install-Module -Name ('ImportExcel','GPRegistryPolicyParser','Plaster','pester') -Scope AllUsers -Force
+Install-Module -Name ('ImportExcel', 'Plaster', 'pester') -Scope AllUsers -Force
+Install-Module -Name 'GPRegistryPolicyParser' -AllowPrerelease -Scope AllUsers -Force
 Install-Module -Name 'AuditPolicyDSC' -RequiredVersion '1.4.0.0' -Scope AllUsers -Force
 Install-Module -Name 'SecurityPolicyDSC' -RequiredVersion '2.10.0.0' -Scope AllUsers -Force


### PR DESCRIPTION
- Solution for #128 
- Latest version of GPRegistryPolicyParser included fixes for PS 7 support which unchains us from 5.1!
- Documentation, tools, and actions have been updated to reflect using PowerShell 7
- 'Prase-PolFile' was changed to 'Read-Polfile' since this was changed in GPRegistryPolicyParser to get rid of the unapproved verb warning at import