### PR TITLE
Generalized parameters on benchmark imports

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - Renamed the 'NewBenchmarkCompositeResource' plaster template to 'NewOSBenchmarkCompositeResource'. This will help facilitate non-OS benchmark support in the future. [Issue 184](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/184)
+- Renamed 'OS' parameter on shared functions to 'System', this included 'Get-CISBenchmarkValidWorksheets' and 'Import-CISBenchmarkData'. [Issue 184](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/184)
 ### Removed
 
 ## [2.3.0] - 2021-02-25

--- a/src/CISDSCResourceGeneration/functions/private/Get-CISBenchmarkValidWorksheets.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Get-CISBenchmarkValidWorksheets.ps1
@@ -21,7 +21,7 @@ function Get-CISBenchmarkValidWorksheets {
 
         [Parameter(Mandatory=$True)]
         [ValidateNotNullOrEmpty()]
-        [string]$OS
+        [string]$System
     )
 
     begin {
@@ -29,7 +29,7 @@ function Get-CISBenchmarkValidWorksheets {
     }
 
     process {
-        switch($OS){
+        switch($System){
             {$_ -like '*Member Server'}{
                 $FilterScript = {$_.Name -ne 'License' -and $_.Name -notlike "*Domain Controller"}
             }

--- a/src/CISDSCResourceGeneration/functions/private/Import-CISBenchmarkData.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-CISBenchmarkData.ps1
@@ -21,7 +21,7 @@ function Import-CISBenchmarkData {
 
         [Parameter(Mandatory=$True)]
         [ValidateNotNullOrEmpty()]
-        [string]$OS
+        [string]$System
     )
 
     begin {
@@ -29,7 +29,7 @@ function Import-CISBenchmarkData {
     }
 
     process {
-        Get-CISBenchmarkValidWorksheets -Path $Path -OS $OS | ForEach-Object -Process {
+        Get-CISBenchmarkValidWorksheets -Path $Path -System $System | ForEach-Object -Process {
             Import-Excel -Path $Path -DataOnly -WorksheetName $_.Name | ForEach-Object -Process {
                 try{
                     if($_.'recommendation #'){

--- a/src/CISDSCResourceGeneration/functions/public/ConvertTo-DSC.ps1
+++ b/src/CISDSCResourceGeneration/functions/public/ConvertTo-DSC.ps1
@@ -76,7 +76,7 @@ function ConvertTo-DSC {
     }
 
     process {
-        Import-CISBenchmarkData -Path $BenchmarkPath -OS $OS
+        Import-CISBenchmarkData -Path $BenchmarkPath -System $OS
 
         if($StaticCorrectionsPath){
             Import-StaticCorrections -Path $StaticCorrectionsPath

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -115,12 +115,12 @@ Describe 'Helper: Get-IniContent' {
 Describe 'Helper: Get-CISBenchmarkValidWorksheets' {
     InModuleScope -ModuleName 'CISDSCResourceGeneration' {
         It 'Returns the correctly filtered workseets' -TestCases @(
-            @{Workbook = 'desktop_examples.xlsx'; OS = 'Microsoft Windows 10 Enterprise'; Expectation = ('Level 1 (L1) - Corporate_Enter','BitLocker (BL) - Level 1 (L1)','Next Generation - Level 1 (L1)','BitLocker (BL) 1 - Level 1 (L1)','Level 2 (L2) - High Security_S','BitLocker (BL) - Level 2 (L2)','Next Generation - Level 2 (L2)','BitLocker (BL) 1 - Level 2 (L2)','BitLocker (BL) - optional add','Next Generation Windows Securi')},
-            @{Workbook = 'server_examples.xlsx'; OS = 'Microsoft Windows Server 2019 Member Server'; Expectation = ('Level 1 - Member Server','Level 2 - Member Server','Next Generation Windows Securi','Next Generation Windows Secur 1')},
-            @{Workbook = 'server_examples.xlsx'; OS = 'Microsoft Windows Server 2019 Domain Controller'; Expectation = ('Level 1 - Domain Controller','Level 2 - Domain Controller','Next Generation Windows Securi','Next Generation Windows Secur 1')}
+            @{Workbook = 'desktop_examples.xlsx'; System = 'Microsoft Windows 10 Enterprise'; Expectation = ('Level 1 (L1) - Corporate_Enter','BitLocker (BL) - Level 1 (L1)','Next Generation - Level 1 (L1)','BitLocker (BL) 1 - Level 1 (L1)','Level 2 (L2) - High Security_S','BitLocker (BL) - Level 2 (L2)','Next Generation - Level 2 (L2)','BitLocker (BL) 1 - Level 2 (L2)','BitLocker (BL) - optional add','Next Generation Windows Securi')},
+            @{Workbook = 'server_examples.xlsx'; System = 'Microsoft Windows Server 2019 Member Server'; Expectation = ('Level 1 - Member Server','Level 2 - Member Server','Next Generation Windows Securi','Next Generation Windows Secur 1')},
+            @{Workbook = 'server_examples.xlsx'; System = 'Microsoft Windows Server 2019 Domain Controller'; Expectation = ('Level 1 - Domain Controller','Level 2 - Domain Controller','Next Generation Windows Securi','Next Generation Windows Secur 1')}
         ){
             [string]$Path = "$($PSScriptRoot)\example_files\$($Workbook)"
-            Get-CISBenchmarkValidWorksheets -Path $Path -OS $OS | Where-Object {$_.Name -notin $Expectation} | Should -Be $Null
+            Get-CISBenchmarkValidWorksheets -Path $Path -System $System | Where-Object {$_.Name -notin $Expectation} | Should -Be $Null
         }
     }
 }
@@ -129,7 +129,7 @@ Describe 'Helper: Import-CISBenchmarkData' {
     InModuleScope -ModuleName 'CISDSCResourceGeneration' {
         It 'Stores [Recommendation] objects in script scope' {
             $script:BenchmarkRecommendations.Clear()
-            Import-CISBenchmarkData -Path "$($PSScriptRoot)\example_files\desktop_examples.xlsx" -OS 'Microsoft Windows 10 Enterprise'
+            Import-CISBenchmarkData -Path "$($PSScriptRoot)\example_files\desktop_examples.xlsx" -System 'Microsoft Windows 10 Enterprise'
             $script:BenchmarkRecommendations.Values[0] -is [Recommendation]
         }
 


### PR DESCRIPTION
- Another piece of preparation for #184 
- 'OS' parameters on helper functions where renamed to 'System'
- Applicable pester tests updated to reflect the rename
- This will ultimately be called differently within ConvertTo-DSC but needs to remain using $OS for now to avoid a breaking change.