### PR TITLE
more noise reduction

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 ### Changed
+- Changed ignored correction from warning to debug since it's intentional behavior. [Issue 182](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/182)
 ### Removed
 
 ## [2.4.0] - 2021-02-26

--- a/src/CISDSCResourceGeneration/functions/private/Get-RecommendationFromGPOHash.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Get-RecommendationFromGPOHash.ps1
@@ -74,7 +74,7 @@ function Get-RecommendationFromGPOHash {
             $script:RecommendationErrors += $GPOHash
         }
         elseif($Recommendation -eq 'ignore'){
-            Write-Warning -Message "Ignoring recommendation error for $($Type) $($CorrectionKey) due to static correction."
+            Write-Debug -Message "Ignoring recommendation error for $($Type) $($CorrectionKey) due to static correction."
         }
         else{
             return $Recommendation.RecommendationNum

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -190,7 +190,7 @@ Describe 'Helper: Get-RecommendationFromGPOHash' {
             Get-RecommendationFromGPOHash -GPOHash @{'Subcategory' = 'Audit Logoff'; 'InclusionSetting' = 'AuditPolicy'} -Type 'AuditPolicy' 3>&1 | Should -Be 'Failed to find a recommendation for AuditPolicy Audit Logoff.'
             Import-StaticCorrections -Path "$($PSScriptRoot)\example_files\static_corrections.csv"
             Get-RecommendationFromGPOHash -GPOHash @{'Subcategory' = 'Audit Logoff'; 'InclusionSetting' = 'AuditPolicy'} -Type 'AuditPolicy' | Should -Be '17.5.3'
-            Get-RecommendationFromGPOHash -GPOHash @{'Name' = 'RasMan'} -Type 'Service' 5>&1 -Debug | Should -Be 'Ignoring recommendation error for Service RasMan due to static correction.'
+            Get-RecommendationFromGPOHash -GPOHash @{'Name' = 'RasMan'} -Type 'Service' -Debug 5>&1 | Should -Be 'Ignoring recommendation error for Service RasMan due to static correction.'
         }
     }
 }

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -190,7 +190,7 @@ Describe 'Helper: Get-RecommendationFromGPOHash' {
             Get-RecommendationFromGPOHash -GPOHash @{'Subcategory' = 'Audit Logoff'; 'InclusionSetting' = 'AuditPolicy'} -Type 'AuditPolicy' 3>&1 | Should -Be 'Failed to find a recommendation for AuditPolicy Audit Logoff.'
             Import-StaticCorrections -Path "$($PSScriptRoot)\example_files\static_corrections.csv"
             Get-RecommendationFromGPOHash -GPOHash @{'Subcategory' = 'Audit Logoff'; 'InclusionSetting' = 'AuditPolicy'} -Type 'AuditPolicy' | Should -Be '17.5.3'
-            Get-RecommendationFromGPOHash -GPOHash @{'Name' = 'RasMan'} -Type 'Service' 3>&1 | Should -Be 'Ignoring recommendation error for Service RasMan due to static correction.'
+            Get-RecommendationFromGPOHash -GPOHash @{'Name' = 'RasMan'} -Type 'Service' 5>&1 -Debug | Should -Be 'Ignoring recommendation error for Service RasMan due to static correction.'
         }
     }
 }


### PR DESCRIPTION
#182 

- Ignoring a correction is something you have to intentionally configure so it makes more sense to have those be output as debug messages rather than warning.