### PR TITLE
Changed setup script from jre to openJDK

### DIFF
--- a/tools/test_machine_setup.ps1
+++ b/tools/test_machine_setup.ps1
@@ -54,8 +54,8 @@ Configuration TestSetup {
             DependsOn = '[cChocoInstaller]installChoco'
         }
         #Needed for CIS-CAT Assessor
-        cChocoPackageInstaller 'InstallJRE8' {
-            Name = 'jre8'
+        cChocoPackageInstaller 'adoptopenjdk16jre' {
+            Name = 'adoptopenjdk16jre'
             Ensure = 'Present'
             DependsOn = '[cChocoInstaller]installChoco'
         }


### PR DESCRIPTION
CISCAT now supports OpenJDK so the setup script has been changed to install that from chocolatey instead of JRE.