### PR TITLE
Win10 20h2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Updated Windows 10 Enterprise 20H2 to v10.0.1 of the benchmark. No functional changes.
+
 ## [2.4.0] - 2021-06-17
 ### Added
 - Added CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 for Server 2019 20H2 [Issue 181](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/181).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Updated Windows 10 Enterprise 20H2 to v10.0.1 of the benchmark. No functional changes.
+- Updated Windows 10 Enterprise 20H2 to v10.0.1 of the benchmark. No functional changes so just increase in version number.
 
 ## [2.4.0] - 2021-06-17
 ### Added

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_20H2/CIS_Microsoft_Windows_10_Enterprise_Release_20H2.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_20H2/CIS_Microsoft_Windows_10_Enterprise_Release_20H2.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_20H2.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '10.0.1.0'
+ModuleVersion = '1.10.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_20H2/CIS_Microsoft_Windows_10_Enterprise_Release_20H2.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_10_Enterprise_Release_20H2/CIS_Microsoft_Windows_10_Enterprise_Release_20H2.psd1
@@ -4,13 +4,13 @@
 RootModule = 'CIS_Microsoft_Windows_10_Enterprise_Release_20H2.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.10.0.1'
+ModuleVersion = '10.0.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
 
 # ID used to uniquely identify this module
-GUID = '073204f5-37b1-486b-9780-2b05d045bd7b'
+GUID = '5d7e37f0-4dae-4888-a274-9964ab198383'
 
 # Author of this module
 # Author = ''


### PR DESCRIPTION
## Guidelines
_Where the guidelines in [CONTRIBUTING.md](/CONTRIBUTING.md) followed?_ Yes

## Purpose
_Describe the problem or feature in addition to a link to the issues._ Bump version to indicate Windows 10 20H2 still matches the new version of the benchmark. The resource was regenerated and there was no difference in the information relevant to the project.

## Approach
_How does this change address the problem?_ The version number is updated to match CIS' documentation.