### PR TITLE
Updated Server 2019 20H2 benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added IconURI to CISDSC manifest
 ### Removed
 - Duplicate keys for next generation windows security in CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
+### Added
+- CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release.[Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 
 ## [2.5.0] - 2021-07-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fixed casing on CISDSC examples directory. [Issue 216](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/216)
 - Added IconURI to CISDSC manifest
+- CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release.[Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 ### Removed
 - Duplicate keys for next generation windows security in CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
-### Added
-- CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release.[Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 
 ## [2.5.0] - 2021-07-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fixed casing on CISDSC examples directory. [Issue 216](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/216)
 - Added IconURI to CISDSC manifest
+### Removed
+- Duplicate keys for next generation windows security in CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 
 ## [2.5.0] - 2021-07-22
 ### Changed

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.md
@@ -1,5 +1,5 @@
 ---
-date: 4/20/2021
+date: 8/30/2021
 keywords: dsc,powershell,configuration,setup,cis,security,20H2
 title: CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
 ---

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.psd1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.psd1
@@ -4,13 +4,13 @@
 RootModule = 'CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.schema.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.2.0.1'
+ModuleVersion = '1.2.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
 
 # ID used to uniquely identify this module
-GUID = '7af63cc1-6c9c-4c03-bba5-2852eecae0d0'
+GUID = 'a1955386-05eb-4107-a000-9ad226c0479c'
 
 # Author of this module
 # Author = ''

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.schema.psm1
@@ -1966,14 +1966,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
         }
     }
     if($ExcludeList -notcontains '18.8.5.1' -and $NextGenerationWindowsSecurity){
-        Registry "18.8.5.1 - (NG) Ensure Turn On Virtualization Based Security is set to Enabled (1)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
-            ValueData = 1
-            ValueName = 'EnableVirtualizationBasedSecurity'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.5.1 - (NG) Ensure Turn On Virtualization Based Security is set to Enabled (2)" {
+        Registry "18.8.5.1 - (NG) Ensure Turn On Virtualization Based Security is set to Enabled" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             ValueData = 1
@@ -1982,14 +1975,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
         }
     }
     if($ExcludeList -notcontains '18.8.5.2' -and $NextGenerationWindowsSecurity){
-        Registry "18.8.5.2 - (NG) Ensure Turn On Virtualization Based Security Select Platform Security Level is set to Secure Boot and DMA Protection (1)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
-            ValueData = 3
-            ValueName = 'RequirePlatformSecurityFeatures'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.5.2 - (NG) Ensure Turn On Virtualization Based Security Select Platform Security Level is set to Secure Boot and DMA Protection (2)" {
+        Registry "18.8.5.2 - (NG) Ensure Turn On Virtualization Based Security Select Platform Security Level is set to Secure Boot and DMA Protection" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             ValueData = 3
@@ -1998,14 +1984,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
         }
     }
     if($ExcludeList -notcontains '18.8.5.3' -and $NextGenerationWindowsSecurity){
-        Registry "18.8.5.3 - (NG) Ensure Turn On Virtualization Based Security Virtualization Based Protection of Code Integrity is set to Enabled with UEFI lock (1)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
-            ValueData = 1
-            ValueName = 'HypervisorEnforcedCodeIntegrity'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.5.3 - (NG) Ensure Turn On Virtualization Based Security Virtualization Based Protection of Code Integrity is set to Enabled with UEFI lock (2)" {
+        Registry "18.8.5.3 - (NG) Ensure Turn On Virtualization Based Security Virtualization Based Protection of Code Integrity is set to Enabled with UEFI lock" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             ValueData = 1
@@ -2014,14 +1993,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
         }
     }
     if($ExcludeList -notcontains '18.8.5.4' -and $NextGenerationWindowsSecurity){
-        Registry "18.8.5.4 - (NG) Ensure Turn On Virtualization Based Security Require UEFI Memory Attributes Table is set to True (checked) (1)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
-            ValueData = 1
-            ValueName = 'HVCIMATRequired'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.5.4 - (NG) Ensure Turn On Virtualization Based Security Require UEFI Memory Attributes Table is set to True (checked) (2)" {
+        Registry "18.8.5.4 - (NG) Ensure Turn On Virtualization Based Security Require UEFI Memory Attributes Table is set to True (checked)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             ValueData = 1
@@ -2030,14 +2002,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
         }
     }
     if($ExcludeList -notcontains '18.8.5.5' -and $NextGenerationWindowsSecurity){
-        Registry "18.8.5.5 - (NG) Ensure Turn On Virtualization Based Security Credential Guard Configuration is set to Enabled with UEFI lock (MS Only) (1)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
-            ValueData = 0
-            ValueName = 'LsaCfgFlags'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.5.5 - (NG) Ensure Turn On Virtualization Based Security Credential Guard Configuration is set to Enabled with UEFI lock (MS Only) (2)" {
+        Registry "18.8.5.5 - (NG) Ensure Turn On Virtualization Based Security Credential Guard Configuration is set to Enabled with UEFI lock (MS Only)" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             ValueData = 1
@@ -2046,14 +2011,7 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
         }
     }
     if($ExcludeList -notcontains '18.8.5.7' -and $NextGenerationWindowsSecurity){
-        Registry "18.8.5.7 - (NG) Ensure Turn On Virtualization Based Security Secure Launch Configuration is set to Enabled (1)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
-            ValueData = 1
-            ValueName = 'ConfigureSystemGuardLaunch'
-            ValueType = 'Dword'
-        }
-        Registry "18.8.5.7 - (NG) Ensure Turn On Virtualization Based Security Secure Launch Configuration is set to Enabled (2)" {
+        Registry "18.8.5.7 - (NG) Ensure Turn On Virtualization Based Security Secure Launch Configuration is set to Enabled" {
             Ensure = 'Present'
             Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             ValueData = 1
@@ -2553,6 +2511,15 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
             ValueType = 'Dword'
         }
     }
+    if($ExcludeList -notcontains '18.9.13.1' -and $LevelTwo){
+        Registry "18.9.13.1 - (L2) Ensure Turn off cloud optimized content is set to Enabled" {
+            Ensure = 'Present'
+            Key = 'HKLM:\Software\Policies\Microsoft\Windows\CloudContent'
+            ValueData = 1
+            ValueName = 'DisableCloudOptimizedContent'
+            ValueType = 'Dword'
+        }
+    }
     if($ExcludeList -notcontains '18.9.13.2' -and $LevelOne){
         Registry "18.9.13.2 - (L1) Ensure Turn off Microsoft consumer experiences is set to Enabled" {
             Ensure = 'Present'
@@ -2787,6 +2754,33 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
             ValueType = 'Dword'
         }
     }
+    if($ExcludeList -notcontains '18.9.45.5.1' -and $LevelTwo){
+        Registry "18.9.45.5.1 - (L2) Ensure Enable file hash computation feature is set to Enabled" {
+            Ensure = 'Present'
+            Key = 'HKLM:\Software\Policies\Microsoft\Windows Defender\MpEngine'
+            ValueData = 1
+            ValueName = 'EnableFileHashComputation'
+            ValueType = 'Dword'
+        }
+    }
+    if($ExcludeList -notcontains '18.9.45.8.1' -and $LevelOne){
+        Registry "18.9.45.8.1 - (L1) Ensure Scan all downloaded files and attachments is set to Enabled" {
+            Ensure = 'Present'
+            Key = 'HKLM:\Software\Policies\Microsoft\Windows Defender\Real-Time Protection'
+            ValueData = 0
+            ValueName = 'DisableIOAVProtection'
+            ValueType = 'Dword'
+        }
+    }
+    if($ExcludeList -notcontains '18.9.45.8.2' -and $LevelOne){
+        Registry "18.9.45.8.2 - (L1) Ensure Turn off real-time protection is set to Disabled" {
+            Ensure = 'Present'
+            Key = 'HKLM:\Software\Policies\Microsoft\Windows Defender\Real-Time Protection'
+            ValueData = 0
+            ValueName = 'DisableRealtimeMonitoring'
+            ValueType = 'Dword'
+        }
+    }
     if($ExcludeList -notcontains '18.9.45.8.3' -and $LevelOne){
         Registry "18.9.45.8.3 - (L1) Ensure Turn on behavior monitoring is set to Enabled" {
             Ensure = 'Present'
@@ -2908,6 +2902,13 @@ Configuration CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
             Key = 'HKLM:\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules'
             ValueData = '1'
             ValueName = 'd4f940ab-401b-4efc-aadc-ad5f3c50688a'
+            ValueType = 'String'
+        }
+        Registry "18.9.45.4.1.2 - (L1) Ensure Configure Attack Surface Reduction rules Set the state for each ASR rule is configured (12)" {
+            Ensure = 'Present'
+            Key = 'HKLM:\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules'
+            ValueData = '1'
+            ValueName = 'e6db77e5-3df2-4cf1-b95a-636979351e5b'
             ValueType = 'String'
         }
     }


### PR DESCRIPTION
## Guidelines
_Where the guidelines in [CONTRIBUTING.md](/CONTRIBUTING.md) followed?_ Yes

## Purpose
_Describe the problem or feature in addition to a link to the issues._ Duplicate keys were discovered when investigating another issue. Resolves #222. 

## Approach
_How does this change address the problem?_
1) Appreciated the irony of finding two copies of keys being issue 222
2) Regenerated with the latest copy of the benchmark from CIS making sure to remove the DC GPOs from the directory. This resulted in a few new keys as well.
