### PR TITLE
v2.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fixed casing on CISDSC examples directory. [Issue 216](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/216)
 - Added IconURI to CISDSC manifest
-- CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release.[Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
+- CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release. [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 ### Removed
 - Duplicate keys for next generation windows security in CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [2.5.1] - 2021-08-31
 ### Changed
 - Fixed casing on CISDSC examples directory. [Issue 216](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/216)
 - Added IconURI to CISDSC manifest

--- a/src/CISDSC/CISDSC.psd1
+++ b/src/CISDSC/CISDSC.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSC.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.5.0'
+ModuleVersion = '2.5.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Finalizes all unreleased changes prior to starting on the v3.0 features such as domain controller support.

## [2.5.1] - 2021-08-31
### Changed
- Fixed casing on CISDSC examples directory. [Issue 216](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/216)
- Added IconURI to CISDSC manifest
- CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release. [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
### Removed
- Duplicate keys for next generation windows security in CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).