### PR TITLE
Fix/issue235

### DIFF
--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - Added an exception for when a parameter does not have a validation block assigned to it. [Issue 233](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/233)
 - Get-CISBenchmarkValidWorksheets was moved to be a public function to help with [Issue 237](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/237)
-
+- Added functionality to ignore GPO files for domain controllers when working on member servers and vice versa. [Issue 235](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/237)
 
 ## [2.4.1] - 2021-08-31
 ### Added

--- a/src/CISDSCResourceGeneration/functions/private/Get-CISValidBuildKitFoldersFilter.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Get-CISValidBuildKitFoldersFilter.ps1
@@ -1,0 +1,42 @@
+<#
+.Synopsis
+    Returns a FilterScript intended to be used by Get-ChildItem for the GPO file imports. This will filter out the MS or DC parts of the build kit when applicable.
+.DESCRIPTION
+    Returns a FilterScript intended to be used by Get-ChildItem for the GPO file imports. This will filter out the MS or DC parts of the build kit when applicable.
+.PARAMETER System
+    The operating system or software the benchmark is written for. This will determine which worksheets are valid to import.
+.EXAMPLE
+    Get-CISValidBuildKitFoldersFilter -System 'Microsoft Windows 10 Enterprise'
+#>
+function Get-CISValidBuildKitFoldersFilter {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]$System
+    )
+
+    begin {
+    }
+
+    process {
+        switch($System){
+            {$_ -like '*Member Server'}{
+                $FilterScript = "*MS-*"
+            }
+
+            {$_ -like '*Domain Controller'}{
+                $FilterScript = "*DC-*"
+            }
+
+            Default{
+                $FilterScript = "*"
+            }
+        }
+
+        return $FilterScript
+    }
+
+    end {
+    }
+}

--- a/src/CISDSCResourceGeneration/functions/private/Import-AudicCsv.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-AudicCsv.ps1
@@ -11,6 +11,8 @@
     ,System,Audit Credential Validation,{0cce923f-69ae-11d9-bed3-505054503030},Success and Failure,,3
 .PARAMETER GPOPath
     Path to the GPO files (build kit) from CIS containing the benchmarks settings.
+.PARAMETER System
+    The operating system or software the benchmark is written for. This will determine which worksheets are valid to import.
 .EXAMPLE
 #>
 function Import-AudicCsv {

--- a/src/CISDSCResourceGeneration/functions/private/Import-AudicCsv.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-AudicCsv.ps1
@@ -15,6 +15,8 @@
 #>
 function Import-AudicCsv {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'System',
+        Justification = 'False positive as rule does not scan child scopes such as Where-Object FilterScript.')]
     param (
         [Parameter(Mandatory=$true)]
         [string]$GPOPath,

--- a/src/CISDSCResourceGeneration/functions/private/Import-AudicCsv.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-AudicCsv.ps1
@@ -1,7 +1,7 @@
 <#
 .Synopsis
-   Recursively finds all 'Audit.csv' files in the provided directory that contain audit policy definitions. Definitions are returned as [ScaffoldingBlock] objects.
-   Ex:
+    Recursively finds all 'Audit.csv' files in the provided directory that contain audit policy definitions. Definitions are returned as [ScaffoldingBlock] objects.
+    Ex:
     Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting,Setting Value
     ,System,Audit Credential Validation,{0cce923f-69ae-11d9-bed3-505054503030},Success and Failure,,3
 .DESCRIPTION
@@ -17,15 +17,18 @@ function Import-AudicCsv {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
-        [string]$GPOPath
+        [string]$GPOPath,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]$System
     )
 
     begin {
-
     }
 
     process {
-        Get-ChildItem -Path $GPOPath -Filter 'Audit.csv' -Recurse | ForEach-Object -Process {
+        Get-ChildItem -Path $GPOPath -Filter 'Audit.csv' -Recurse | Where-Object -FilterScript {$_.FullName -like (Get-CISValidBuildKitFoldersFilter -System $System)} | ForEach-Object -Process {
             Write-Verbose -Message "Importing $($_.FullName)"
             $CSV = Import-CSV -Path $_.FullName
 
@@ -39,6 +42,5 @@ function Import-AudicCsv {
     }
 
     end {
-
     }
 }

--- a/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
@@ -13,6 +13,8 @@
 #>
 function Import-GptTmpl {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'System',
+        Justification = 'False positive as rule does not scan child scopes such as Where-Object FilterScript.')]
     param (
         [Parameter(Mandatory=$true)]
         [string]$GPOPath,

--- a/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
@@ -9,6 +9,8 @@
     Ex: Registry Values, Privilege Rights, System Access, and Service General Setting.
 .PARAMETER GPOPath
     Path to the GPO files (build kit) from CIS containing the benchmarks settings.
+.PARAMETER System
+    The operating system or software the benchmark is written for. This will determine which worksheets are valid to import.
 .EXAMPLE
 #>
 function Import-GptTmpl {

--- a/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-GptTmpl.ps1
@@ -1,12 +1,12 @@
 <#
 .Synopsis
-   Recursively finds all 'GptTmpl.inf' files in the provided directory that contain misc. settings.
-   Some information on these files can be found here: http://techgenix.com/group-policy-settings-part1/
-   Ex: Registry Values, Privilege Rights, System Access, and Service General Setting.
+    Recursively finds all 'GptTmpl.inf' files in the provided directory that contain misc. settings.
+    Some information on these files can be found here: http://techgenix.com/group-policy-settings-part1/
+    Ex: Registry Values, Privilege Rights, System Access, and Service General Setting.
 .DESCRIPTION
-   Recursively finds all 'GptTmpl.inf' files in the provided directory that contain misc. settings.
-   Some information on these files can be found here: http://techgenix.com/group-policy-settings-part1/
-   Ex: Registry Values, Privilege Rights, System Access, and Service General Setting.
+    Recursively finds all 'GptTmpl.inf' files in the provided directory that contain misc. settings.
+    Some information on these files can be found here: http://techgenix.com/group-policy-settings-part1/
+    Ex: Registry Values, Privilege Rights, System Access, and Service General Setting.
 .PARAMETER GPOPath
     Path to the GPO files (build kit) from CIS containing the benchmarks settings.
 .EXAMPLE
@@ -15,15 +15,18 @@ function Import-GptTmpl {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
-        [string]$GPOPath
+        [string]$GPOPath,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]$System
     )
 
     begin {
-
     }
 
     process {
-        Get-ChildItem -Path $GPOPath -Filter 'GptTmpl.inf' -Recurse | Foreach-Object -Process {
+        Get-ChildItem -Path $GPOPath -Filter 'GptTmpl.inf' -Recurse | Where-Object -FilterScript {$_.FullName -like (Get-CISValidBuildKitFoldersFilter -System $System)} | Foreach-Object -Process {
             Write-Verbose -Message "Importing $($_.FullName)"
             $ini = Get-IniContent -Path $_.fullname
 
@@ -46,6 +49,5 @@ function Import-GptTmpl {
     }
 
     end {
-
     }
 }

--- a/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
@@ -1,16 +1,16 @@
 <#
 .Synopsis
-   Recursively finds all 'registry.pol' files in the provided directory that contain abstracted registry settings.
-   These are settings defined by admx templates that result in registry settings. They differ from a GptTmpl.inf registry values
-   because they are not explictly configured within group policy as registry keys.
+    Recursively finds all 'registry.pol' files in the provided directory that contain abstracted registry settings.
+    These are settings defined by admx templates that result in registry settings. They differ from a GptTmpl.inf registry values
+    because they are not explictly configured within group policy as registry keys.
 
-   This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
+    This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
 .DESCRIPTION
-   Recursively finds all 'registry.pol' files in the provided directory that contain abstracted registry settings.
-   These are settings defined by admx templates that result in registry settings. They differ from a GptTmpl.inf registry values
-   because they are not explictly configured within group policy as registry keys.
+    Recursively finds all 'registry.pol' files in the provided directory that contain abstracted registry settings.
+    These are settings defined by admx templates that result in registry settings. They differ from a GptTmpl.inf registry values
+    because they are not explictly configured within group policy as registry keys.
 
-   This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
+    This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
 .PARAMETER GPOPath
     Path to the GPO files (build kit) from CIS containing the benchmarks settings.
 .EXAMPLE
@@ -19,15 +19,18 @@ function Import-RegistryPol {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string]$GPOPath
+        [string]$GPOPath,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]$System
     )
 
     begin {
-
     }
 
     process {
-        Get-ChildItem -Path $GPOPath -Filter 'registry.pol' -Recurse | ForEach-Object -Process {
+        Get-ChildItem -Path $GPOPath -Filter 'registry.pol' -Recurse | Where-Object -FilterScript {$_.FullName -like (Get-CISValidBuildKitFoldersFilter -System $System)} | ForEach-Object -Process {
             Write-Verbose -Message "Importing $($_.FullName)"
             $PolicyData = Read-PolFile -Path $_.FullName
 
@@ -42,6 +45,5 @@ function Import-RegistryPol {
     }
 
     end {
-
     }
 }

--- a/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
@@ -13,6 +13,8 @@
     This function relies on the GPRegistryPolicyParser module by MicroSoft. https://github.com/PowerShell/GPRegistryPolicyParser
 .PARAMETER GPOPath
     Path to the GPO files (build kit) from CIS containing the benchmarks settings.
+.PARAMETER System
+    The operating system or software the benchmark is written for. This will determine which worksheets are valid to import.
 .EXAMPLE
 #>
 function Import-RegistryPol {

--- a/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
+++ b/src/CISDSCResourceGeneration/functions/private/Import-RegistryPol.ps1
@@ -17,6 +17,8 @@
 #>
 function Import-RegistryPol {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'System',
+        Justification = 'False positive as rule does not scan child scopes such as Where-Object FilterScript.')]
     param (
         [Parameter(Mandatory = $true)]
         [string]$GPOPath,

--- a/src/CISDSCResourceGeneration/functions/public/ConvertTo-DSC.ps1
+++ b/src/CISDSCResourceGeneration/functions/public/ConvertTo-DSC.ps1
@@ -89,7 +89,8 @@ function ConvertTo-DSC {
     process {
         #The use of get-variable here is a little hack to avoid needing a switch statement.
         #It assumes the value we care about is stored in a variable of the same name as the parameter set.
-        Import-CISBenchmarkData -Path $BenchmarkPath -System (Get-Variable -Name $PSCmdlet.ParameterSetName).Value
+        $System = (Get-Variable -Name $PSCmdlet.ParameterSetName).Value
+        Import-CISBenchmarkData -Path $BenchmarkPath -System $System
 
         if($StaticCorrectionsPath){
             Import-StaticCorrections -Path $StaticCorrectionsPath
@@ -107,9 +108,9 @@ function ConvertTo-DSC {
             New-Item -Path $OutputPath -ItemType 'Directory' | Out-Null
         }
 
-        Import-GptTmpl -GPOPath $GPOPath
-        Import-AudicCsv -GPOPath $GPOPath
-        Import-RegistryPol -GPOPath $GPOPath
+        Import-GptTmpl -GPOPath $GPOPath -System $System
+        Import-AudicCsv -GPOPath $GPOPath -System $System
+        Import-RegistryPol -GPOPath $GPOPath -System $System
 
         Export-RecommendationErrors -OutputPath $OutputPath
         Export-MissingRecommendations -OutputPath $OutputPath

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -249,19 +249,25 @@ Describe 'Helper: Conversion functions' {
 
 Describe 'Helper: File import functions' {
     InModuleScope -ModuleName 'CISDSCResourceGeneration' {
+        It 'Get-CISValidBuildKitFoldersFilter correctly filters GPO folders' {
+            Get-CISValidBuildKitFoldersFilter -System "Member Server" | Should -Be "*MS-*"
+            Get-CISValidBuildKitFoldersFilter -System "Domain Controller" | Should -Be "*DC-*"
+            Get-CISValidBuildKitFoldersFilter -System "Workstation" | Should -Be "*"
+        }
+
         It 'Import-AudicCsv returns objects from a valid Audit.csv' {
             [string]$GPOPath = "$($PSScriptRoot)\example_files"
-            {Import-AudicCsv -GPOPath $GPOPath -WarningAction SilentlyContinue} | Should -Not -Throw
+            {Import-AudicCsv -GPOPath $GPOPath -System "Workstation" -WarningAction SilentlyContinue} | Should -Not -Throw
         }
 
         It 'Import-GptTmpl returns objects from a valid GptTmpl.inf' {
             [string]$GPOPath = "$($PSScriptRoot)\example_files"
-            {Import-GptTmpl -GPOPath $GPOPath -WarningAction SilentlyContinue} | Should -Not -Throw
+            {Import-GptTmpl -GPOPath $GPOPath -System "Workstation" -WarningAction SilentlyContinue} | Should -Not -Throw
         }
 
         It 'Import-RegistryPol returns objects from a valid registry.pol' {
             [string]$GPOPath = "$($PSScriptRoot)\example_files"
-            {Import-RegistryPol -GPOPath $GPOPath -WarningAction SilentlyContinue} | Should -Not -Throw
+            {Import-RegistryPol -GPOPath $GPOPath -System "Workstation" -WarningAction SilentlyContinue} | Should -Not -Throw
         }
     }
 }
@@ -290,9 +296,9 @@ Describe 'Helper: Import-ParameterValidations' {
 Describe 'Helper: Text block generation' {
     InModuleScope -ModuleName 'CISDSCResourceGeneration' {
         #This test must take place after Helper: Import-CISBenchmarkData
-        Import-GptTmpl -GPOPath "$($PSScriptRoot)\example_files" -WarningAction SilentlyContinue
-        Import-AudicCsv -GPOPath "$($PSScriptRoot)\example_files" -WarningAction SilentlyContinue
-        Import-RegistryPol -GPOPath "$($PSScriptRoot)\example_files" -WarningAction SilentlyContinue
+        Import-GptTmpl -GPOPath "$($PSScriptRoot)\example_files" -System 'Workstation' -WarningAction SilentlyContinue
+        Import-AudicCsv -GPOPath "$($PSScriptRoot)\example_files" -System 'Workstation' -WarningAction SilentlyContinue
+        Import-RegistryPol -GPOPath "$($PSScriptRoot)\example_files" -System 'Workstation' -WarningAction SilentlyContinue
 
         It 'Lists the appropriate levels' {
             (Get-ApplicableLevels -Recommendations ($script:BenchmarkRecommendations).Values | Measure-Object).Count | Should -be 4


### PR DESCRIPTION
## Guidelines
_Where the guidelines in [CONTRIBUTING.md](/CONTRIBUTING.md) followed?_ Yes

## Purpose
_Describe the problem or feature in addition to a link to the issues._ resolves #235 

## Approach
_How does this change address the problem?_ I've added the helper function "Get-CISValidBuildKitFoldersFilter" to generate a string filter for the appropriate GPO folders when importing. This was added to all relevant locations for GPO file imports.
The helper function will ensure that DC/MS folders in the CIS build kits are ignored when importing on the opposite type.
![image](https://user-images.githubusercontent.com/28571284/139319500-7b15bf18-255d-419f-b60c-50674c00254a.png)

