### PR TITLE
Fix/issue248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,92 +1,148 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - Fixed missing validate range for cis189623101MaxIdleTime in benchmark CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
 - Corrected Changelog and License URIs in the manifest to be raw links
 
-## [2.5.1] - 2021-08-31
+## [2.5.2] - 2022-03-16
+
 ### Changed
+
+- Resource generation no longer generates DSCTitles that exceeded character limits for use in Azure. [Issue 248](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/248)
+- Design choice
+
+## [2.5.1] - 2021-08-31
+
+### Changed
+
 - Fixed casing on CISDSC examples directory. [Issue 216](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/216)
 - Added IconURI to CISDSC manifest
 - CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 updated to latest benchmark release. [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
+
 ### Removed
+
 - Duplicate keys for next generation windows security in CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [Issue 222](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/222).
 
 ## [2.5.0] - 2021-07-22
+
 ### Changed
+
 - Updated Windows 10 Enterprise 20H2 to v10.0.1 of the benchmark. No functional changes so just increase in version number.
+
 ### Added
+
 - Added new DSC resource for Windows 10 enterprise 21H1. CIS_Microsoft_Windows_10_Enterprise_Release_21H1 [Issue 208](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/208)
 
 ## [2.4.0] - 2021-06-17
+
 ### Added
+
 - Added CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 for Server 2019 20H2 [Issue 181](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/181).
+
 ### Changed
+
 - Updated the validation range for 1.1.2 MaximumPasswordAge to be 1-60 instead of 60-999 after reviewing CIS documentation per [Issue 204](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/204)
+
 ### Removed
 
 ## [2.3.0] - 2021-03-02
+
 ### Added
+
 - Added CIS_Microsoft_Edge_Windows resource for applying benchmarks for Edge on Windows [Issue 185](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/185)
+
 ### Changed
+
 ### Removed
 
 ## [2.2.0] - 2021-01-29
+
 ### Added
+
 - Added new DSC resource for Windows 10 enterprise 20H2. CIS_Microsoft_Windows_10_Enterprise_Release_20H2 [Issue 166](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/166)
+
 ### Changed
+
 ### Removed
 
 ## [2.1.1] - 2021-01-26
+
 ### Added
+
 ### Changed
+
 - All parameter names with a lead numeric character (those associated with recommendations) have been prefixed with an "cis". This is to allign with standard naming conventions for DSC resources and to resolve issues with platforms such as Azure Automation and AWX. THIS IS A BREAKING CHANGE FOR EXISTING CONFIGURATIONS.
 - Corrected references of 'ExclusionList' to 'ExcludeList'
+
 ### Removed
 
 ## [2.0.1] - 2020-10-30
+
 ### Added
+
 - Added RunAsAdministrator requirement to packaged examples
+
 ### Changed
+
 - Updated Windows 10 Enterprise 2004 to v1.9.1 of the benchmark [Issue 146](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/146)
 - Various standardization and grammar adjustments in examples and documentation
+
 ### Removed
 
 ## [2.0.0] - 2020-10-19
+
 ### Added
+
 - Added resource for Windows Server 2019 Release 1809 [Issue 7](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/7)
 - Added resource for Windows Server 2016 Release 1607 [Issue 6](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/6)
+
 ### Changed
+
 - Corrected ScreenSaverGracePeriod registry key to apply as a string instead of a Dword in Windows 10 Enterprise 1809, 1909, and 2004. [Issue 136](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/136)
 - Correct the parameter validation 2374InactivityTimeoutSecs to be a ValidateRange not ValidateLength in Windows 10 Enterprise 1809, 1909, and 2004. [Issue 135](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/135)
 
 ## [1.1.0] - 2020-10-05
+
 ### Added
+
 - Added CISService resource. This is a custom resource for managing services that will consider an absent or disabled service to be in desired state.
+
 ### Changed
+
 - Updated Windows 10 Enterprise 1809, 1909, and 2004 to use the new CISService resource. This means users will no longer have to explicitly exclude absent services from their configurations to avoid errors. This is not a breaking a change.
+
 ### Removed
+
 - Removed duplicate entry for HKLM:\SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}:NoGPOListChanges in Windows 10 Enterprise 1809
 
 ## [1.0.2] - 2020-09-30
+
 ### Added
+
 - Added missing parameter validation for 189623101MaxIdleTime in Windows 10 Enterprise 2004
 - Added docs folder within the module outlining the Windows 10 resources
 
 ## [1.0.1] - 2020-09-21
+
 ### Added
+
 - Added missing key for HKLM:\SOFTWARE\Policies\Microsoft\AppHVSI:AppHVSIClipboardFileType to Windows 10 Enterprise 2004 18.9.46.5
 
 ### Changed
+
 - Corrected values for "18.8.7.1.5 - (BL) Ensure Prevent installation of devices using drivers that match these device setup classes Prevent installation of devices using drivers for these device setup is set to IEEE 1394 device setup classes" across multiple resources. These were previously being pinned to 18.8.7.1.4 with bad values in 18.8.7.1.5
 - Reinstated parameter for 1.1.4 (L1) Ensure 'Minimum password length' is set to '14 or more character(s)' to the Windows 10 Enterprise 2004 resource as this setting was changed to accept up to 128 characters in this build.
 
 ## [1.0.0] - 2020-09-15
+
 ### Added
+
 - Added DSC resource for Windows 10 Enterprise 1809 based on benchmark v1.6.1
 - Windows 10 Enterprise 1903 is intentionally omitted due to approaching EOL
 - Added DSC resource for Windows 10 Enterprise 1909 based on benchmark v1.8.1

--- a/docs/design_choices.md
+++ b/docs/design_choices.md
@@ -1,26 +1,39 @@
 # Design choices
+
 This document outlines justifications for design choices through out this project that may not be obvious at first.
 
+## Recommendation title length
+
+Recommendation titles have been truncated to 256 characters as a result of [#248](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/248). This was causing PSScriptAnalyzer heart burn as well as various other quirks.
+
 ## Parameter name prefixes
-Parameter names have all been prefixed with "cis" as a result of [#169](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/169). This was causing PSScriptAnalyzer heart burn as well as various other quirks.
+
+Parameter names have all been prefixed with "cis" as a result of [#169](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/169). This is a known limitation in Azure.
 
 ## CISService over Service
+
 This class based resource was introduced due to [#121](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/121). The actual CIS recommendation was that a given service was absent or disabled. The native service resource from PSDesiredStateConfiguration did not achieve this and also required that absent services be known ahead of time and added to the excludelist. This approach was both a quality of life improvement and more in line with the benchmark itself.
 
 ## Build specific CSVs
+
 This is due to the fact CIS reserves the right to change recommendation IDs which are used in these corrections. A specific recommendation may carry over to the next build of the OS but have a different ID. There is also different IDs for the same recommendations between server and workstation in many cases.
 
 ## Legal notice and local account renames have no default values
+
 These are by nature incredibly specific to the envrionment a given host exists in so a reasonable default value does not exist.
 
 ## BaselineManagement forked and not just marked as a dependency
+
 There were several bugs within BaselineManagement combined with our very specific use case for its functionality so it was heavily modified and baked into CISDSCResourceGeneration instead.
 
 ## User based settings are not supported
+
 While technically possible through DSC we made a decision at the start not to support these. Because popular opinion is these are best managed via group policy and the situations in which it's even possible to use DSC are rare which didn't make it worth while.
 
 ## Not supporting legacy formatting of the CIS documents
+
 CIS benchmarks evolve with every revision and the same goes for the document format. It would be difficult to guarantee every difference between documentation generations is accounted for so while older generations will likely work with minimum modification to the document (primarily worksheet names) we will only explicitly support/test the latest generation.
 
 ## No longer requiring CIS-CAT reports for new resources
+
 CIS-CAT scans had a lot of value early in the project when bugs where being discovered and squashed however it's value has diminished rapidly as the code base has matured. This is combined with the facts that this is often the longest phase of developing a resource and causes the biggest delays due to CIS-CAT lagging in support of new benchmarks for weeks or months in some cases. We have opted to commit to a "sanity check" with CIS-CAT every other build when it becomes available but not make it a requirement for release.

--- a/docs/design_choices.md
+++ b/docs/design_choices.md
@@ -4,11 +4,11 @@ This document outlines justifications for design choices through out this projec
 
 ## Recommendation title length
 
-Recommendation titles have been truncated to 256 characters as a result of [#248](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/248). This was causing PSScriptAnalyzer heart burn as well as various other quirks.
+Recommendation titles have been truncated to 256 characters as a result of [#248](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/248). This is a known limitation in Azure.
 
 ## Parameter name prefixes
 
-Parameter names have all been prefixed with "cis" as a result of [#169](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/169). This is a known limitation in Azure.
+Parameter names have all been prefixed with "cis" as a result of [#169](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/169). This was causing PSScriptAnalyzer heart burn as well as various other quirks.
 
 ## CISService over Service
 

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
@@ -110,9 +110,11 @@ Class Recommendation{
         $This.SectionNum = $ExcelRow.'section #'
         $This.RecommendationNum = $ExcelRow.'recommendation #'
         #Quotes are normalized for consistentcy in checks.
-        $This.Title = $ExcelRow.Title.Replace('"',"'")
+        $This.Title = ($ExcelRow.Title.Replace('"',"'"))
         #Most special characters are filtered out of the title for the DSC resource. This prevents various encoding issues. Recommendation number is added to the start to prevent duplicate titles between recommendations which does occur.
         $This.DSCTitle = "$($This.RecommendationNum) - $($This.Title)" -replace "[^a-zA-Z0-9-() .]",""
+        #DSCTitle needs to be truncated to 165 chars to avoid limitations in Azure
+        $This.DSCTitle = ($This.DSCTitle).Substring(0, [System.Math]::Min(165, $This.DSCTitle.length))
         $This.Description = $ExcelRow.Description
         $This.RemediationProcedure = $ExcelRow.'remediation procedure'
         $This.AuditProcedure = $ExcelRow.'audit procedure'

--- a/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
+++ b/src/CISDSCResourceGeneration/CISDSCResourceGeneration.psm1
@@ -110,7 +110,7 @@ Class Recommendation{
         $This.SectionNum = $ExcelRow.'section #'
         $This.RecommendationNum = $ExcelRow.'recommendation #'
         #Quotes are normalized for consistentcy in checks.
-        $This.Title = ($ExcelRow.Title.Replace('"',"'"))
+        $This.Title = $ExcelRow.Title.Replace('"',"'")
         #Most special characters are filtered out of the title for the DSC resource. This prevents various encoding issues. Recommendation number is added to the start to prevent duplicate titles between recommendations which does occur.
         $This.DSCTitle = "$($This.RecommendationNum) - $($This.Title)" -replace "[^a-zA-Z0-9-() .]",""
         #DSCTitle needs to be truncated to 165 chars to avoid limitations in Azure

--- a/test/CISDSCResourceGeneration.Tests.ps1
+++ b/test/CISDSCResourceGeneration.Tests.ps1
@@ -69,6 +69,13 @@ Describe 'Class: Recommendation' {
             $Recommendation2.UpdateForDSCParameter()
             $Recommendation2.NeedsParameter | Should -Be $True
         }
+
+        It 'Truncates the DSCTitle to 165 characters'{
+            $ExcelExample = (Import-Excel -Path "$($PSScriptRoot)\example_files\desktop_examples.xlsx" -WorksheetName 'BitLocker (BL) - Level 2 (L2)' |
+                Where-Object -FilterScript {$_.'Recommendation #' -eq '18.8.7.1.5'})
+            $ExpectedLength = 166
+            ([Recommendation]::New($ExcelExample)).DSCTitle.length | Should -BeLessThan $ExpectedLength
+        }
     }
 }
 


### PR DESCRIPTION

## Purpose
Truncate recommendation DSCTitles to 165 characters and update design choices document to reflect this change.
https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/248

## Approach
Updates recommendation class in CISDSCResourceGeneration and adds accompanying pester test

## Note
Prettier automatically formats markdown documents I've edited according to standard which accounts for all the additional newlines. 
