### PR TITLE
LAPS product ID change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.1.0] - 2022-12-05
+
+### Changed
+
+- Old LAPS Product ID replaced with new
+
 ## [3.0.0] - 2022-11-30
 
 ### Added

--- a/CHANGELOG_CISDSCResourceGeneration.md
+++ b/CHANGELOG_CISDSCResourceGeneration.md
@@ -1,103 +1,160 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - Added an exception for when a parameter does not have a validation block assigned to it. [Issue 233](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/233)
 - Get-CISBenchmarkValidWorksheets was moved to be a public function to help with [Issue 237](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/237)
 - Added functionality to ignore GPO files for domain controllers when working on member servers and vice versa. [Issue 235](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/237)
 - Added Server 2022 to accepted OS names in ConvertTo-DSC [Issue 252](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/252)
 
+## [2.4.2] - 2022-11-18
+
+### Changed
+
+- Fix in GET-RecommendationFromGPOHash for NUL characters in registry policy files
+
 ## [2.4.1] - 2021-08-31
+
 ### Added
+
 - Added script analyzer exceptions for plural nouns
 - Added missing comment based help
+
 ### Changed
+
 - Changed ignored correction from warning to debug since it's intentional behavior. [Issue 182](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/182)
 - Updated Get-CISBenchmarkValidWorksheets logic for the new excel sheet format from CIS.
 - Fix for "Get-RecommendationFromGPOHash fails to find DC AuditPolicy settings" [Issue 225](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/225)
+
 ### Removed
 
 ## [2.4.0] - 2021-02-26
+
 ### Added
+
 - Implimented support for browser based benchmarks. This primarily meant adding parameter sets to ConvertTo-DSC and a new plaster templates in addition to the two changes below.
+
 ### Changed
+
 - Renamed the 'NewBenchmarkCompositeResource' plaster template to 'NewOSBenchmarkCompositeResource'. This will help facilitate non-OS benchmark support in the future. [Issue 184](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/184)
 - Renamed 'OS' parameter on shared functions to 'System', this included 'Get-CISBenchmarkValidWorksheets' and 'Import-CISBenchmarkData'. [Issue 184](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/184)
 
-
 ## [2.3.0] - 2021-02-25
+
 ### Changed
+
 - Updated the module to work with the latest release of GPRegistryPolicyParser and increased the minimum version to 7. [Issue 128](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/128)
 - Resolved the unapproved verb warning at import this was fixed along side PS 7 support in the latest version of GPRegistryPolicyParser.
 
 ## 2.2.9
+
 ### Changed
+
 - Converted expected warning messages to debug within Import-GptTmpl and Import-RegistryPol per [Issue 182](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/182)
 
 ## 2.2.8
+
 ### Added
+
 - Added support for ignoring settings within static corrections per [Issue 178](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/178). Details can be found in the [static corrections doc](docs/static_corrections.md#How-do-I-ignore-a-recommendation-error?)
+
 ### Changed
+
 ### Removed
 
 ## 2.2.7
+
 ### Added
+
 ### Changed
+
 - UserRightsAssignment's 'Identities' property will now be sorted so that SIDs will be consistently ordered between resources per [Issue 175](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/175).
+
 ### Removed
 
 ## 2.2.6
+
 ### Added
+
 ### Changed
+
 - Corrected issues with the plaster template variables introduced in 2.2.5
+
 ### Removed
 
 ## 2.2.5
+
 ### Added
+
 ### Changed
+
 - Updated all references to parameter names to be prefixed with an "cis" per [Issue 169](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/169)
 - Corrected several instance of ExclusionList to ExcludeList
+
 ### Removed
 
 ## 2.2.4
+
 ### Changed
+
 - Updated the Plaster template to take the OS name with and without underscores. [Issue 159](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/159)
 
 ## 2.2.3
+
 ### Changed
+
 - Fixed a few missed casing fixes for [Issue 143](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/143)
 
 ## 2.2.2
+
 ### Changed
+
 - Standardized casing for typing on resource parameters [Issue 143](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/143)
 - Corrected plaster template for resource documentation to use the dynamic recommendation IDs from [Issue 129](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/129)
 
 ## 2.2.1
+
 ### Added
+
 - Added resource example files to the Plaster template [Issue 133](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/133)
+
 ### Changed
+
 - Corrected special case for HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\ScreenSaverGracePeriod incorrectly setting to DWORD instead of string [Issue 136](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/136)
 
 ## 2.2.0
+
 ### Added
+
 - Added support for overriding parameters that are generated [Issue 71](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/71)
 
 ## 2.1.2
+
 ### Added
+
 - Added support for dynamic setting on recommendation IDs on the special case recommendations (legal notice and account renames) [Issue 129](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/129)
 
 ## 2.1.1
+
 ### Added
+
 ### Changed
+
 - Changed service logic to use the CISService resource [Issue 121](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/121)
+
 ### Removed
 
 ## 2.1 - 9/30/20
+
 ### Added
+
 - Functionality to generate resource documentation along side the DSC resources [Issue 114](https://github.com/techservicesillinois/SecOps-Powershell-CISDSC/issues/114)
 
 ## [2.0.0]
+
 - Start of changelog

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1809.md
@@ -3,6 +3,7 @@ date: 9/30/2020
 keywords: dsc,powershell,configuration,setup,cis,security,1809
 title: CIS_Microsoft_Windows_10_Enterprise_Release_1809
 ---
+
 # DSC CIS_Microsoft_Windows_10_Enterprise_Release_1809 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -52,8 +53,8 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -61,50 +62,51 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1809 [String] #ResourceName
 > `cis2316AccountsRenameguestaccount`,
 > `cis2376LegalNoticeCaption`,
 > `cis2375LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|BitLocker |`$false` | |Applies bitlocker recommendations |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| BitLocker                                  | `$false`     |                   | Applies bitlocker recommendations                                                                                                                                    |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 1            | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis114MinimumPasswordLength                | 14           | 1.1.4             | (L1) Ensure 'Minimum password length' is set to '14 or more character(s)'                                                                                            |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'                                                                                     |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'                                                                                |
+| cis18410ScreenSaverGracePeriod             | '0'          | 18.4.10           | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18413WarningLevel                       | 90           | 18.4.13           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189593101MaxIdleTime                    | 900000       | 18.9.59.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'                                            |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373MaxDevicePasswordFailedAttempts     | 10           | 2.3.7.3           | (BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0'                                         |
+| cis2374InactivityTimeoutSecs               | 900          | 2.3.7.4           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2375LegalNoticeText                     |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2376LegalNoticeCaption                  |              | 2.3.7.6           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2377CachedLogonsCount                   | '4'          | 2.3.7.7           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'                     |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -154,6 +156,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -166,7 +169,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_1909.md
@@ -3,6 +3,7 @@ date: 9/30/2020
 keywords: dsc,powershell,configuration,setup,cis,security,1909
 title: CIS_Microsoft_Windows_10_Enterprise_Release_1909
 ---
+
 # DSC CIS_Microsoft_Windows_10_Enterprise_Release_1909 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -52,8 +53,8 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -61,50 +62,51 @@ CIS_Microsoft_Windows_10_Enterprise_Release_1909 [String] #ResourceName
 > `cis2316AccountsRenameguestaccount`,
 > `cis2376LegalNoticeCaption`,
 > `cis2375LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|BitLocker |`$false` | |Applies bitlocker recommendations |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| BitLocker                                  | `$false`     |                   | Applies bitlocker recommendations                                                                                                                                    |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 1            | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis114MinimumPasswordLength                | 14           | 1.1.4             | (L1) Ensure 'Minimum password length' is set to '14 or more character(s)'                                                                                            |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'                                                                                     |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'                                                                                |
+| cis18410ScreenSaverGracePeriod             | '0'          | 18.4.10           | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18413WarningLevel                       | 90           | 18.4.13           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189593101MaxIdleTime                    | 900000       | 18.9.59.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'                                            |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373MaxDevicePasswordFailedAttempts     | 10           | 2.3.7.3           | (BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0'                                         |
+| cis2374InactivityTimeoutSecs               | 900          | 2.3.7.4           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2375LegalNoticeText                     |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2376LegalNoticeCaption                  |              | 2.3.7.6           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2377CachedLogonsCount                   | '4'          | 2.3.7.7           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'                     |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -154,6 +156,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -166,7 +169,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_2004.md
@@ -3,6 +3,7 @@ date: 9/30/2020
 keywords: dsc,powershell,configuration,setup,cis,security,2004
 title: CIS_Microsoft_Windows_10_Enterprise_Release_2004
 ---
+
 # DSC CIS_Microsoft_Windows_10_Enterprise_Release_2004 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -52,8 +53,8 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -61,50 +62,51 @@ CIS_Microsoft_Windows_10_Enterprise_Release_2004 [String] #ResourceName
 > `cis2316AccountsRenameguestaccount`,
 > `cis2376LegalNoticeCaption`,
 > `cis2375LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|BitLocker |`$false` | |Applies bitlocker recommendations |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189623101MaxIdleTime |900000 |18.9.62.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| BitLocker                                  | `$false`     |                   | Applies bitlocker recommendations                                                                                                                                    |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 1            | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis114MinimumPasswordLength                | 14           | 1.1.4             | (L1) Ensure 'Minimum password length' is set to '14 or more character(s)'                                                                                            |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'                                                                                     |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'                                                                                |
+| cis18410ScreenSaverGracePeriod             | '0'          | 18.4.10           | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18413WarningLevel                       | 90           | 18.4.13           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189623101MaxIdleTime                    | 900000       | 18.9.62.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'                                            |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373MaxDevicePasswordFailedAttempts     | 10           | 2.3.7.3           | (BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0'                                         |
+| cis2374InactivityTimeoutSecs               | 900          | 2.3.7.4           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2375LegalNoticeText                     |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2376LegalNoticeCaption                  |              | 2.3.7.6           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2377CachedLogonsCount                   | '4'          | 2.3.7.7           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'                     |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -154,6 +156,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -166,7 +169,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_20H2.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_20H2.md
@@ -3,6 +3,7 @@ date: 1/28/2021
 keywords: dsc,powershell,configuration,setup,cis,security,20H2
 title: CIS_Microsoft_Windows_10_Enterprise_Release_20H2
 ---
+
 # DSC CIS_Microsoft_Windows_10_Enterprise_Release_20H2 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -52,8 +53,8 @@ CIS_Microsoft_Windows_10_Enterprise_Release_20H2 [String] #ResourceName
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -61,50 +62,51 @@ CIS_Microsoft_Windows_10_Enterprise_Release_20H2 [String] #ResourceName
 > `2316AccountsRenameguestaccount`,
 > `2376LegalNoticeCaption`,
 > `2375LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|BitLocker |`$false` | |Applies bitlocker recommendations |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189623101MaxIdleTime |900000 |18.9.62.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| BitLocker                                  | `$false`     |                   | Applies bitlocker recommendations                                                                                                                                    |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 1            | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis114MinimumPasswordLength                | 14           | 1.1.4             | (L1) Ensure 'Minimum password length' is set to '14 or more character(s)'                                                                                            |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'                                                                                     |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'                                                                                |
+| cis18410ScreenSaverGracePeriod             | '0'          | 18.4.10           | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18413WarningLevel                       | 90           | 18.4.13           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189623101MaxIdleTime                    | 900000       | 18.9.62.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)'                         |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373MaxDevicePasswordFailedAttempts     | 10           | 2.3.7.3           | (BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0'                                         |
+| cis2374InactivityTimeoutSecs               | 900          | 2.3.7.4           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2375LegalNoticeText                     |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2376LegalNoticeCaption                  |              | 2.3.7.6           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2377CachedLogonsCount                   | '4'          | 2.3.7.7           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'                     |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -154,6 +156,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -166,7 +169,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_20H2 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_21H1.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_10_Enterprise_Release_21H1.md
@@ -3,6 +3,7 @@ date: 7/20/2021
 keywords: dsc,powershell,configuration,setup,cis,security,21H1
 title: CIS_Microsoft_Windows_10_Enterprise_Release_21H1
 ---
+
 # DSC CIS_Microsoft_Windows_10_Enterprise_Release_21H1 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -52,8 +53,8 @@ CIS_Microsoft_Windows_10_Enterprise_Release_21H1 [String] #ResourceName
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -61,50 +62,51 @@ CIS_Microsoft_Windows_10_Enterprise_Release_21H1 [String] #ResourceName
 > `2316AccountsRenameguestaccount`,
 > `2376LegalNoticeCaption`,
 > `2375LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|BitLocker |`$false` | |Applies bitlocker recommendations |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |365 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '365 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis114MinimumPasswordLength |14 |1.1.4 |(L1) Ensure 'Minimum password length' is set to '14 or more character(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |5 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '5 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' |
-|cis18410ScreenSaverGracePeriod |'0' |18.4.10 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18413WarningLevel |90 |18.4.13 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis18910312DeferFeatureUpdatesPeriodInDays |180 |18.9.103.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189633101MaxIdleTime |900000 |18.9.63.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373MaxDevicePasswordFailedAttempts |10 |2.3.7.3 |(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0' |
-|cis2374InactivityTimeoutSecs |900 |2.3.7.4 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2375LegalNoticeText | |2.3.7.5 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2376LegalNoticeCaption | |2.3.7.6 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2377CachedLogonsCount |'4' |2.3.7.7 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| BitLocker                                  | `$false`     |                   | Applies bitlocker recommendations                                                                                                                                    |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 365          | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '365 or fewer days, but not 0'                                                                                          |
+| cis113MinimumPasswordAge                   | 1            | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis114MinimumPasswordLength                | 14           | 1.1.4             | (L1) Ensure 'Minimum password length' is set to '14 or more character(s)'                                                                                            |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 5            | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '5 or fewer invalid logon attempt(s), but not 0'                                                                   |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more'                                                                                     |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer'                                                                                |
+| cis18410ScreenSaverGracePeriod             | '0'          | 18.4.10           | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18413WarningLevel                       | 90           | 18.4.13           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis18910312DeferFeatureUpdatesPeriodInDays | 180          | 18.9.103.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189633101MaxIdleTime                    | 900000       | 18.9.63.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)'                         |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373MaxDevicePasswordFailedAttempts     | 10           | 2.3.7.3           | (BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0'                                         |
+| cis2374InactivityTimeoutSecs               | 900          | 2.3.7.4           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2375LegalNoticeText                     |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2376LegalNoticeCaption                  |              | 2.3.7.6           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2377CachedLogonsCount                   | '4'          | 2.3.7.7           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)'                     |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -154,6 +156,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -166,7 +169,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_21H1 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607.md
@@ -3,6 +3,7 @@ date: 10/19/2020
 keywords: dsc,powershell,configuration,setup,cis,security,1607
 title: CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607
 ---
+
 # DSC CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -49,8 +50,8 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -58,47 +59,48 @@ CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 [String] #ResourceN
 > `cis2316AccountsRenameguestaccount`,
 > `cis2376LegalNoticeCaption`,
 > `cis2375LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |1 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
-|cis18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 1            | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only)                                                                           |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only)                                                                      |
+| cis18412WarningLevel                       | 90           | 18.4.12           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis1849ScreenSaverGracePeriod              | '0'          | 18.4.9            | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189593101MaxIdleTime                    | 900000       | 18.9.59.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'                                            |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373InactivityTimeoutSecs               | 900          | 2.3.7.3           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2374LegalNoticeText                     |              | 2.3.7.4           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2375LegalNoticeCaption                  |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2376CachedLogonsCount                   | '4'          | 2.3.7.6           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only)           |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -148,6 +150,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -160,7 +163,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809.md
@@ -3,6 +3,7 @@ date: 10/15/2020
 keywords: dsc,powershell,configuration,setup,cis,security,1809
 title: CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809
 ---
+
 # DSC CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -49,8 +50,8 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -58,47 +59,48 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 [String] #ResourceN
 > `cis2316AccountsRenameguestaccount`,
 > `cis2375LegalNoticeCaption`,
 > `cis2374LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |30 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
-|cis18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189593101MaxIdleTime |900000 |18.9.59.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 30           | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only)                                                                           |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only)                                                                      |
+| cis18412WarningLevel                       | 90           | 18.4.12           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis1849ScreenSaverGracePeriod              | '0'          | 18.4.9            | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189593101MaxIdleTime                    | 900000       | 18.9.59.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less'                                            |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373InactivityTimeoutSecs               | 900          | 2.3.7.3           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2374LegalNoticeText                     |              | 2.3.7.4           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2375LegalNoticeCaption                  |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2376CachedLogonsCount                   | '4'          | 2.3.7.6           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only)           |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -148,6 +150,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -160,7 +163,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 'CISBenchmarks'

--- a/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.md
+++ b/src/CISDSC/docs/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2.md
@@ -3,6 +3,7 @@ date: 10/27/2021
 keywords: dsc,powershell,configuration,setup,cis,security,20H2
 title: CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2
 ---
+
 # DSC CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
@@ -49,8 +50,8 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [String] #ResourceN
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -58,47 +59,48 @@ CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 [String] #ResourceN
 > `2316AccountsRenameguestaccount`,
 > `2375LegalNoticeCaption`,
 > `2374LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
-|ExcludeList | | |Excludes the provided recommendation IDs from the configuration |
-|LevelOne |`$true` | |Applies level one recommendations |
-|LevelTwo |`$false` | |Applies level two recommendations. Does not include level one, both must be set to `$true`. |
-|NextGenerationWindowsSecurity |`$false` | |Applies Next Generation Windows Security recommendations |
-|cis112MaximumPasswordAge |60 |1.1.2 |(L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0' |
-|cis113MinimumPasswordAge |30 |1.1.3 |(L1) Ensure 'Minimum password age' is set to '1 or more day(s)' |
-|cis121Accountlockoutduration |15 |1.2.1 |(L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)' |
-|cis122Accountlockoutthreshold |10 |1.2.2 |(L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0' |
-|cis123Resetaccountlockoutcounterafter |15 |1.2.3 |(L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' |
-|cis1825PasswordLength |15 |18.2.5 |(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only) |
-|cis1826PasswordAgeDays |30 |18.2.6 |(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only) |
-|cis18412WarningLevel |90 |18.4.12 |(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less' |
-|cis1849ScreenSaverGracePeriod |'0' |18.4.9 |(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
-|cis18910212DeferFeatureUpdatesPeriodInDays |180 |18.9.102.1.2 |(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days' |
-|cis1892612MaxSize |32768 |18.9.26.1.2 |(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892622MaxSize |196608 |18.9.26.2.2 |(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater' |
-|cis1892632MaxSize |32768 |18.9.26.3.2 |(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis1892642MaxSize |32768 |18.9.26.4.2 |(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater' |
-|cis189623101MaxIdleTime |900000 |18.9.62.3.10.1 |(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)' |
-|cis2315AccountsRenameadministratoraccount | |2.3.1.5 |(L1) Configure 'Accounts: Rename administrator account' |
-|cis2316AccountsRenameguestaccount | |2.3.1.6 |(L1) Configure 'Accounts: Rename guest account' |
-|cis2365MaximumPasswordAge |30 |2.3.6.5 |(L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0' |
-|cis2373InactivityTimeoutSecs |900 |2.3.7.3 |(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0' |
-|cis2374LegalNoticeText | |2.3.7.4 |(L1) Configure 'Interactive logon: Message text for users attempting to log on' |
-|cis2375LegalNoticeCaption | |2.3.7.5 |(L1) Configure 'Interactive logon: Message title for users attempting to log on' |
-|cis2376CachedLogonsCount |'4' |2.3.7.6 |(L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only) |
-|cis2391AutoDisconnect |15 |2.3.9.1 |(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)' |
-|cis916LogFileSize |16384 |9.1.6 |(L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis926LogFileSize |16384 |9.2.6 |(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
-|cis938LogFileSize |16384 |9.3.8 |(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater' |
+| Property                                   | DefaultValue | Recommendation ID | Recommendation                                                                                                                                                       |
+| ------------------------------------------ | ------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ExcludeList                                |              |                   | Excludes the provided recommendation IDs from the configuration                                                                                                      |
+| LevelOne                                   | `$true`      |                   | Applies level one recommendations                                                                                                                                    |
+| LevelTwo                                   | `$false`     |                   | Applies level two recommendations. Does not include level one, both must be set to `$true`.                                                                          |
+| NextGenerationWindowsSecurity              | `$false`     |                   | Applies Next Generation Windows Security recommendations                                                                                                             |
+| cis112MaximumPasswordAge                   | 60           | 1.1.2             | (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'                                                                                           |
+| cis113MinimumPasswordAge                   | 30           | 1.1.3             | (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'                                                                                                      |
+| cis121Accountlockoutduration               | 15           | 1.2.1             | (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'                                                                                              |
+| cis122Accountlockoutthreshold              | 10           | 1.2.2             | (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'                                                                  |
+| cis123Resetaccountlockoutcounterafter      | 15           | 1.2.3             | (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'                                                                                   |
+| cis1825PasswordLength                      | 15           | 18.2.5            | (L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only)                                                                           |
+| cis1826PasswordAgeDays                     | 30           | 18.2.6            | (L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only)                                                                      |
+| cis18412WarningLevel                       | 90           | 18.4.12           | (L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'       |
+| cis1849ScreenSaverGracePeriod              | '0'          | 18.4.9            | (L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds' |
+| cis18910212DeferFeatureUpdatesPeriodInDays | 180          | 18.9.102.1.2      | (L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: Semi-Annual Channel, 180 or more days'                                 |
+| cis1892612MaxSize                          | 32768        | 18.9.26.1.2       | (L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                             |
+| cis1892622MaxSize                          | 196608       | 18.9.26.2.2       | (L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'                                                               |
+| cis1892632MaxSize                          | 32768        | 18.9.26.3.2       | (L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                   |
+| cis1892642MaxSize                          | 32768        | 18.9.26.4.2       | (L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'                                                                  |
+| cis189623101MaxIdleTime                    | 900000       | 18.9.62.3.10.1    | (L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)'                         |
+| cis2315AccountsRenameadministratoraccount  |              | 2.3.1.5           | (L1) Configure 'Accounts: Rename administrator account'                                                                                                              |
+| cis2316AccountsRenameguestaccount          |              | 2.3.1.6           | (L1) Configure 'Accounts: Rename guest account'                                                                                                                      |
+| cis2365MaximumPasswordAge                  | 30           | 2.3.6.5           | (L1) Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'                                                            |
+| cis2373InactivityTimeoutSecs               | 900          | 2.3.7.3           | (L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'                                                              |
+| cis2374LegalNoticeText                     |              | 2.3.7.4           | (L1) Configure 'Interactive logon: Message text for users attempting to log on'                                                                                      |
+| cis2375LegalNoticeCaption                  |              | 2.3.7.5           | (L1) Configure 'Interactive logon: Message title for users attempting to log on'                                                                                     |
+| cis2376CachedLogonsCount                   | '4'          | 2.3.7.6           | (L2) Ensure 'Interactive logon: Number of previous logons to cache (in case domain controller is not available)' is set to '4 or fewer logon(s)' (MS only)           |
+| cis2391AutoDisconnect                      | 15           | 2.3.9.1           | (L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'                                     |
+| cis916LogFileSize                          | 16384        | 9.1.6             | (L1) Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
+| cis926LogFileSize                          | 16384        | 9.2.6             | (L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                   |
+| cis938LogFileSize                          | 16384        | 9.3.8             | (L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'                                                                    |
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -148,6 +150,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -160,7 +163,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 'CISBenchmarks'

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_1809_With_LAPS.ps1
@@ -18,7 +18,7 @@ Configuration Win10_1809_L1_With_LAPS
         Package 'InstallLAPS' {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1809 'CIS Benchmarks' {

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_1909_With_LAPS.ps1
@@ -18,7 +18,7 @@ Configuration Win10_1909_L1_With_LAPS
         Package 'InstallLAPS' {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_1909 'CIS Benchmarks' {

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_2004_With_LAPS.ps1
@@ -19,7 +19,7 @@ Configuration Microsoft_Windows_10_Enterprise_2004_CIS_L1_with_LAPS
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_2004 'CIS Benchmarks'

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_20H2_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_20H2_With_LAPS.ps1
@@ -19,7 +19,7 @@ Configuration Microsoft_Windows_10_Enterprise_20H2_CIS_L1_with_LAPS
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_20H2 'CIS Benchmarks'

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_21H1_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_10_Enterprise_Release_21H1_With_LAPS.ps1
@@ -19,7 +19,7 @@ Configuration Microsoft_Windows_10_Enterprise_21H1_CIS_L1_with_LAPS
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_10_Enterprise_Release_21H1 'CIS Benchmarks'

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607_With_LAPS.ps1
@@ -18,7 +18,7 @@ Configuration Microsoft_Windows_Server_2016_Member_Server_1607_CIS_L1_with_LAPS
         Package 'InstallLAPS' {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_Server_2016_Member_Server_Release_1607 'CIS Benchmarks'

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809_With_LAPS.ps1
@@ -18,7 +18,7 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_1809_CIS_L1_with_LAPS
         Package 'InstallLAPS' {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_1809 'CIS Benchmarks'

--- a/src/CISDSC/examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2_With_LAPS.ps1
+++ b/src/CISDSC/examples/CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2_With_LAPS.ps1
@@ -19,7 +19,7 @@ Configuration Microsoft_Windows_Server_2019_Member_Server_20H2_CIS_L1_with_LAPS
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_Microsoft_Windows_Server_2019_Member_Server_Release_20H2 'CIS Benchmarks'

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewOSBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewOSBenchmarkCompositeResource/example_With_LAPS.ps1.plaster
@@ -19,7 +19,7 @@ Configuration <%=$PLASTER_PARAM_OSWithUnderscores%>_<%=$PLASTER_PARAM_OSBuild%>_
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CIS Benchmarks'

--- a/src/CISDSCResourceGeneration/plasterTemplates/NewOSBenchmarkCompositeResource/resource.documentation.md
+++ b/src/CISDSCResourceGeneration/plasterTemplates/NewOSBenchmarkCompositeResource/resource.documentation.md
@@ -3,11 +3,12 @@ date: <%=$PLASTER_Date%>
 keywords: dsc,powershell,configuration,setup,cis,security,<%=$PLASTER_PARAM_OSBuild%>
 title: CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>
 ---
-# DSC CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> Resource
+
+# DSC CIS*<%=$PLASTER_PARAM_OSWithUnderscores%>\_Release*<%=$PLASTER_PARAM_OSBuild%> Resource
 
 > Applies To: Windows PowerShell 5.1 and higher
 
-The **CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%>** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+The **CIS*<%=$PLASTER_PARAM_OSWithUnderscores%>\_Release*<%=$PLASTER_PARAM_OSBuild%>** resource in Windows PowerShell Desired State Configuration (DSC) provides a
 mechanism to apply CIS benchmarks on a target node running <%=$PLASTER_PARAM_OS%> release <%=$PLASTER_PARAM_OSBuild%>.
 
 ## Syntax
@@ -20,8 +21,8 @@ CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> [S
     [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
-> [!NOTE]
-> `[String]` parameters with a number range specifies valid lengths.
+
+> [!NOTE] > `[String]` parameters with a number range specifies valid lengths.
 
 > [!NOTE]
 > The following parameters are mandatory if not added to the ExcludeList. This is because these values will always be organization specific so a default value is not appropriate.
@@ -29,18 +30,20 @@ CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> [S
 > `<%=$PLASTER_PARAM_AccountsRenameguestaccountNumNoDots%>AccountsRenameguestaccount`,
 > `<%=$PLASTER_PARAM_LegalNoticeCaptionNumNoDots%>LegalNoticeCaption`,
 > `<%=$PLASTER_PARAM_LegalNoticeTextNumNoDots%>LegalNoticeText`
+
 ## Properties
 
-|Property |DefaultValue | Recommendation ID|Recommendation
-|---|---|---|---|
+| Property | DefaultValue | Recommendation ID | Recommendation |
+| -------- | ------------ | ----------------- | -------------- |
+
 <%=$PLASTER_PARAM_DocumentationPropertyTable%>
 
 ## Common properties
 
-|Property |Description |
-|---|---|
-|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+| Property             | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DependsOn            | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+| PsDscRunAsCredential | Sets the credential for running the entire resource as.                                                                                                                                                                                                                                                                        |
 
 > [!NOTE]
 > The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
@@ -90,6 +93,7 @@ Configuration MyConfiguration
 ```
 
 ### Example 3: Apply benchmarks with a dependency on LAPS
+
 ```powershell
 Configuration MyConfiguration
 {
@@ -102,7 +106,7 @@ Configuration MyConfiguration
         {
             Name  = 'Local Administrator Password Solution'
             Path = 'https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi'
-            ProductId = 'EA8CB806-C109-4700-96B4-F1F268E5036C'
+            ProductId = '97E2CA7B-B657-4FF7-A6DB-30ECC73E1E28'
         }
 
         CIS_<%=$PLASTER_PARAM_OSWithUnderscores%>_Release_<%=$PLASTER_PARAM_OSBuild%> 'CISBenchmarks'


### PR DESCRIPTION
## [3.1.0] - 2022-12-05

### Changed

- Old LAPS Product ID replaced with new

Note: Prettier also cleaned up a lot of the markdown. Load the richdiff to see that nothing really changed visually

Resolves #261 