### PR TITLE
Fix/283

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [4.0.1] - 2024-04-17
+
+### Added
+
+- Removed 'Ensure Turn on PowerShell Transcription is set to Enabled (2)' and (3). These are subkeys of 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription' (OutputDirectory and EnableInvocationHeader) which are not mentioned by the CIS Benchmark and erroneously included in the GPOKit. Invalid ValueData for the OutputDirectory key is also causing issues with the MOF file depending on how it's generated.
+
 ## [4.0.0] - 2024-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.1] - 2024-04-17
 
-### Added
+### Removed
 
 - Removed 'Ensure Turn on PowerShell Transcription is set to Enabled (2)' and (3). These are subkeys of 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription' (OutputDirectory and EnableInvocationHeader) which are not mentioned by the CIS Benchmark and erroneously included in the GPOKit. Invalid ValueData for the OutputDirectory key is also causing issues with the MOF file depending on how it's generated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed 'Ensure Turn on PowerShell Transcription is set to Enabled (2)' and (3). These are subkeys of 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription' (OutputDirectory and EnableInvocationHeader) which are not mentioned by the CIS Benchmark and erroneously included in the GPOKit. Invalid ValueData for the OutputDirectory key is also causing issues with the MOF file depending on how it's generated.
+- Removed 'Ensure Turn on PowerShell Transcription is set to Enabled (2)' and (3). These are subkeys of 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription' (OutputDirectory and EnableInvocationHeader) which are not mentioned by the CIS Benchmark and erroneously included in the GPOKit. Invalid ValueData for the OutputDirectory key was also causing issues with the MOF file in some cases, depending on how it was generated.
 
 ## [4.0.0] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [4.0.1] - 2024-04-17
-
 ### Removed
 
 - Removed 'Ensure Turn on PowerShell Transcription is set to Enabled (2)' and (3). These are subkeys of 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription' (OutputDirectory and EnableInvocationHeader) which are not mentioned by the CIS Benchmark and erroneously included in the GPOKit. Invalid ValueData for the OutputDirectory key is also causing issues with the MOF file depending on how it's generated.

--- a/src/CISDSC/CISDSC.psd1
+++ b/src/CISDSC/CISDSC.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSC.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.0'
+ModuleVersion = '4.0.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/CISDSC.psd1
+++ b/src/CISDSC/CISDSC.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CISDSC.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.1'
+ModuleVersion = '4.0.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/CISDSC/dscresources/CIS_Microsoft_Windows_11_Enterprise_Release_23H2/CIS_Microsoft_Windows_11_Enterprise_Release_23H2.schema.psm1
+++ b/src/CISDSC/dscresources/CIS_Microsoft_Windows_11_Enterprise_Release_23H2/CIS_Microsoft_Windows_11_Enterprise_Release_23H2.schema.psm1
@@ -4711,18 +4711,6 @@ Configuration CIS_Microsoft_Windows_11_Enterprise_Release_23H2
             ValueName = 'EnableTranscripting'
             ValueType = 'Dword'
         }
-        Registry "18.10.87.2 - (L1) Ensure Turn on PowerShell Transcription is set to Enabled (2)" {
-            Ensure = 'Present'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription'
-            ValueData = ' '
-            ValueName = 'OutputDirectory'
-            ValueType = 'String'
-        }
-        Registry "18.10.87.2 - (L1) Ensure Turn on PowerShell Transcription is set to Enabled (3)" {
-            Ensure = 'Absent'
-            Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription'
-            ValueName = 'EnableInvocationHeader'
-        }
     }
     if($ExcludeList -notcontains '18.10.89.1.1' -and $LevelOne){
         Registry "18.10.89.1.1 - (L1) Ensure Allow Basic authentication is set to Disabled" {


### PR DESCRIPTION
## Unreleased

### Removed

- Removed 'Ensure Turn on PowerShell Transcription is set to Enabled (2)' and (3). These are subkeys of 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription' (OutputDirectory and EnableInvocationHeader) which are not mentioned by the CIS Benchmark and erroneously included in the GPOKit. Invalid ValueData for the OutputDirectory key is also causing issues with the MOF file depending on how it's generated.

Resolves #283 

After this is merged I will release 4.0.1